### PR TITLE
DisplayCal is starting on Windows10 with Python3.8

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -141,7 +141,7 @@ from DisplayCAL.meta import (
     VERSION_BASE,
     author,
     name as appname,
-    domain,
+    DOMAIN,
     version,
     version_short,
     get_latest_changelog_entry,
@@ -358,7 +358,7 @@ def app_update_check(parent=None, silent=False, snapshot=False, argyll=False):
         chglog_file = "CHANGES.html"
     resp = http_request(
         parent,
-        domain,
+        DOMAIN,
         "GET",
         "/" + version_file,
         failure_msg=lang.getstr("update_check.fail"),
@@ -377,12 +377,12 @@ def app_update_check(parent=None, silent=False, snapshot=False, argyll=False):
     try:
         newversion_tuple = tuple(int(n) for n in data.decode().split("."))
     except ValueError:
-        print(lang.getstr("update_check.fail.version", domain))
+        print(lang.getstr("update_check.fail.version", DOMAIN))
         if not silent:
             wx.CallAfter(
                 InfoDialog,
                 parent,
-                msg=lang.getstr("update_check.fail.version", domain),
+                msg=lang.getstr("update_check.fail.version", DOMAIN),
                 ok=lang.getstr("ok"),
                 bitmap=geticon(32, "dialog-error"),
                 log=False,
@@ -393,7 +393,7 @@ def app_update_check(parent=None, silent=False, snapshot=False, argyll=False):
         APP_IS_UPTODATE = newversion_tuple <= curversion_tuple
     if newversion_tuple > curversion_tuple:
         # Get changelog
-        resp = http_request(parent, domain, "GET", "/" + chglog_file, silent=True)
+        resp = http_request(parent, DOMAIN, "GET", "/" + chglog_file, silent=True)
         chglog = None
         if resp:
             readme = str(resp.read())
@@ -421,7 +421,7 @@ def app_update_check(parent=None, silent=False, snapshot=False, argyll=False):
                 )
                 chglog = re.sub(
                     re.compile(r'href="(#[^"]+)"', flags=re.I),
-                    r'href="https://%s/\1"' % domain,
+                    rf'href="https://{DOMAIN}/\1"',
                     chglog,
                 )
         if not wx.GetApp():
@@ -616,7 +616,7 @@ def app_update_confirm(
                     "--refresh",
                     "--version",
                     newversion,
-                    "http://%s/0install/%s.xml" % (domain.lower(), appname),
+                    f"http://{DOMAIN}/0install/{appname}.xml",
                 ],
                 **kwargs,
             )
@@ -671,8 +671,7 @@ def app_update_confirm(
                 worker.download,
                 ckwargs={"exit": dlname == appname},
                 wargs=(
-                    "https://%s/download%s/%s%s%s%s"
-                    % (domain.lower(), folder, dlname, sep, newversion, suffix),
+                    f"https://{DOMAIN}/download{folder}/{dlname}{sep}{sep}{suffix}",
                 ),
                 progress_msg=lang.getstr("downloading"),
                 fancy=False,
@@ -689,7 +688,7 @@ def app_update_confirm(
             else:
                 # Linux
                 path += "-linux"
-        launch_file("https://" + domain + path)
+        launch_file(f"https://{DOMAIN}{path}")
     elif not argyll:
         # Check for Argyll update
         if check_argyll_bin():
@@ -744,7 +743,7 @@ def donation_message(parent=None):
     dlg.sizer0.SetSizeHints(dlg)
     dlg.sizer0.Layout()
     if dlg.ShowModal() == wx.ID_OK:
-        launch_file("https://" + domain + "/#donate")
+        launch_file(f"https://{DOMAIN}/#donate")
         show_again = False
     else:
         show_again = not chkbox.Value
@@ -1151,7 +1150,7 @@ def upload_colorimeter_correction(parent=None, params=None):
     # Check for duplicate
     resp = http_request(
         parent,
-        "colorimetercorrections." + domain,
+        f"colorimetercorrections.{DOMAIN}",
         "GET",
         path,
         # Remove CREATED date for calculating hash
@@ -1179,7 +1178,7 @@ def upload_colorimeter_correction(parent=None, params=None):
         params["put"] = True
         resp = http_request(
             parent,
-            "colorimetercorrections." + domain,
+            f"colorimetercorrections.{DOMAIN}",
             "POST",
             path,
             params,
@@ -3099,7 +3098,7 @@ class MainFrame(ReportFrame, BaseFrame):
         self.Bind(wx.EVT_MENU, self.license_handler, self.menuitem_license)
         menuitem = help.FindItemById(help.FindItem("go_to_website"))
         self.Bind(
-            wx.EVT_MENU, lambda event: launch_file("https://%s/" % domain), menuitem
+            wx.EVT_MENU, lambda event: launch_file(f"https://{DOMAIN}/"), menuitem
         )
         menuitem = help.FindItemById(help.FindItem("help_support"))
         self.Bind(wx.EVT_MENU, self.help_support_handler, menuitem)
@@ -5808,7 +5807,7 @@ class MainFrame(ReportFrame, BaseFrame):
                 if result and not isinstance(result, Exception):
                     return result
             # Download from web
-            path = self.worker.download("https://%s/spyd2" % domain.lower())
+            path = self.worker.download(f"https://{DOMAIN}/spyd2")
             if isinstance(path, Exception):
                 return path
             elif not path:
@@ -7971,7 +7970,7 @@ class MainFrame(ReportFrame, BaseFrame):
             http_request,
             ckwargs={},
             wkwargs={
-                "domain": domain.lower() if test else "icc.opensuse.org",
+                "DOMAIN": DOMAIN if test else "icc.opensuse.org",
                 "request_type": "POST",
                 "path": "/print_r_post.php" if test else "/upload",
                 "params": params,
@@ -12395,7 +12394,7 @@ class MainFrame(ReportFrame, BaseFrame):
             ckwargs={"parent": self},
             wargs=(
                 self,
-                "colorimetercorrections." + domain,
+                f"colorimetercorrections.{DOMAIN}",
                 "GET",
                 "/index.php",
                 params,
@@ -14700,7 +14699,7 @@ class MainFrame(ReportFrame, BaseFrame):
                 # We always (re-)download the i1D3 package because it may contain
                 # additional corrections not present in i1Profiler
                 result = self.worker.download(
-                    "https://%s/%s" % (domain.lower(), name), force=name == "i1d3"
+                    f"https://{DOMAIN}/{name}", force=name == "i1d3"
                 )
                 if isinstance(result, Exception):
                     break
@@ -18751,7 +18750,7 @@ class MainFrame(ReportFrame, BaseFrame):
                     self.aboutdialog.panel,
                     -1,
                     label=appname,
-                    URL="https://%s/" % domain,
+                    URL=f"https://{DOMAIN}/",
                 ),
                 wx.StaticText(
                     self.aboutdialog.panel, -1, " %s © %s" % (version_title, author)
@@ -18898,10 +18897,10 @@ class MainFrame(ReportFrame, BaseFrame):
             launch_file(license)
 
     def help_support_handler(self, event):
-        launch_file("https://%s/#help" % domain)
+        launch_file(f"https://{DOMAIN}/#help")
 
     def bug_report_handler(self, event):
-        launch_file("https://%s/#reportbug" % domain)
+        launch_file(f"https://{DOMAIN}/#reportbug")
 
     def app_update_check_handler(self, event, silent=False, argyll=False):
         if (

--- a/DisplayCAL/gtypes.py
+++ b/DisplayCAL/gtypes.py
@@ -25,4 +25,4 @@ class GQuark(guint32):
 
 
 class GError(Structure):
-    _fields_ = [("domain", GQuark), ("code", gint), ("message", gchar_p)]
+    _fields_ = [("DOMAIN", GQuark), ("code", gint), ("message", gchar_p)]

--- a/DisplayCAL/meta.py
+++ b/DisplayCAL/meta.py
@@ -40,10 +40,10 @@ longdesc = (
     "LUTs, as well as optional CIECAM02 gamut mapping to "
     "take into account varying viewing conditions."
 )
-domain = "displaycal.net"
-author_email = "florian" + chr(0o100) + domain
+DOMAIN = "displaycal.net"
+author_email = "florian" + chr(0o100) + DOMAIN
 name = "DisplayCAL"
-appstream_id = ".".join(reversed([name] + domain.lower().split(".")))
+appstream_id = ".".join(reversed([name] + DOMAIN.split(".")))
 name_html = '<span class="appname">Display<span>CAL</span></span>'
 
 py_minversion = (3, 8)

--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -57,7 +57,7 @@ if sys.platform == "win32":
     )
     from DisplayCAL.debughelpers import Error, UnloggedError, handle_error
     from DisplayCAL.edid import get_edid
-    from DisplayCAL.meta import domain
+    from DisplayCAL.meta import DOMAIN
     from DisplayCAL.ordereddict import OrderedDict
 
     # from collections import OrderedDict
@@ -167,8 +167,7 @@ if sys.platform == "win32":
                                         "--offline",
                                         "--command=run-apply-profiles",
                                         "--",
-                                        "http://%s/0install/%s.xml"
-                                        % (domain.lower(), appname),
+                                        f"http://{DOMAIN}/0install/{appname}.xml",
                                         "--task",
                                     ]
                                 )
@@ -2234,7 +2233,7 @@ class ProfileLoader(object):
                                 "--no-wait",
                                 "--offline",
                                 "--command=run-apply-profiles",
-                                "http://%s/0install/%s.xml" % (domain.lower(), appname),
+                                f"http://{DOMAIN}/0install/{appname}.xml",
                             ]
                         )
                     else:

--- a/DisplayCAL/setup.py
+++ b/DisplayCAL/setup.py
@@ -63,7 +63,7 @@ from DisplayCAL.meta import (
     author_ascii,
     description,
     longdesc,
-    domain,
+    DOMAIN,
     name,
     py_maxversion,
     py_minversion,
@@ -214,7 +214,7 @@ plist_dict = {
     "CFBundleDevelopmentRegion": "English",
     "CFBundleExecutable": name,
     "CFBundleGetInfoString": version,
-    "CFBundleIdentifier": ".".join(reversed(domain.split("."))) + "." + name,
+    "CFBundleIdentifier": ".".join(reversed(DOMAIN.split("."))) + "." + name,
     "CFBundleInfoDictionaryVersion": "6.0",
     "CFBundleLongVersionString": version,
     "CFBundleName": name,
@@ -1036,7 +1036,7 @@ setup(ext_modules=[Extension("%s.lib%s.RealDisplaySizeMM", sources=%r, define_ma
         "description": description,
         "download_url": "https://%(domain)s/download/"
         "%(name)s-%(version)s.tar.gz"
-        % {"domain": domain, "name": name, "version": version},
+        % {"DOMAIN": DOMAIN, "name": name, "version": version},
         "ext_modules": ext_modules,
         "license": "GPL v3",
         "long_description": longdesc,
@@ -1057,7 +1057,7 @@ setup(ext_modules=[Extension("%s.lib%s.RealDisplaySizeMM", sources=%r, define_ma
         "requires": requires,
         "provides": [name],
         "scripts": [],
-        "url": "https://%s/" % domain,
+        "url": f"https://{DOMAIN}/",
         "version": msiversion if "bdist_msi" in sys.argv[1:] else version,
     }
 

--- a/DisplayCAL/wxwindows.py
+++ b/DisplayCAL/wxwindows.py
@@ -5236,19 +5236,18 @@ fancytext.Renderer.getCurrentColor = fancytext_Renderer_getCurrentColor
 fancytext.Renderer.getCurrentFont = fancytext_Renderer_getCurrentFont
 
 
-def fancytext_RenderToRenderer(str, renderer, enclose=True):
-    str = safe_str(str, "UTF-8")
+def fancytext_RenderToRenderer(text, renderer, enclose=True):
+    text = safe_str(text, "UTF-8")
     try:
         if enclose:
-            str = '<?xml version="1.0"?><FancyText>%s</FancyText>' % str
+            text = f'<?xml version="1.0"?><FancyText>{text}</FancyText>'
         p = xml.parsers.expat.ParserCreate()
-        p.returns_unicode = 1
         p.StartElementHandler = renderer.startElement
         p.EndElementHandler = renderer.endElement
         p.CharacterDataHandler = renderer.characterData
-        p.Parse(str, 1)
+        p.Parse(text, True)
     except xml.parsers.expat.error as err:
-        raise ValueError('error parsing text text "%s": %s' % (str, err))
+        raise ValueError(f'error parsing text text "{text}": {err}') from err
 
 
 fancytext.RenderToRenderer = fancytext_RenderToRenderer

--- a/DisplayCAL/x3dom.py
+++ b/DisplayCAL/x3dom.py
@@ -12,7 +12,7 @@ import urllib.parse
 
 from DisplayCAL.config import get_data_path
 from DisplayCAL.defaultpaths import cache as cachepath
-from DisplayCAL.meta import domain
+from DisplayCAL.meta import DOMAIN
 from DisplayCAL.options import verbose, debug
 from DisplayCAL.util_io import GzipFileProper
 from DisplayCAL.util_str import StrList, create_replace_function
@@ -171,7 +171,7 @@ class Tag(object):
 
         # Get HTML template from cache or online
         html = get_resource(
-            "https://%s/x3d-viewer/release/x3d-viewer.html" % domain.lower(), True
+            f"https://{DOMAIN}/x3d-viewer/release/x3d-viewer.html", True
         )
         if cache or embed:
             # Update resources in HTML

--- a/setup.py
+++ b/setup.py
@@ -538,7 +538,7 @@ def setup():
         description,
         lastmod,
         longdesc,
-        domain,
+        DOMAIN,
         py_maxversion,
         py_minversion,
         version,
@@ -744,16 +744,16 @@ def setup():
                 "AppName": name,
                 "AppVerName": version,
                 "AppPublisher": author,
-                "AppPublisherURL": f"https://{domain}/",
-                "AppSupportURL": f"https://{domain}/",
-                "AppUpdatesURL": f"https://{domain}/",
+                "AppPublisherURL": f"https://{DOMAIN}/",
+                "AppSupportURL": f"https://{DOMAIN}/",
+                "AppUpdatesURL": f"https://{DOMAIN}/",
                 "VersionInfoVersion": ".".join(map(str, version_tuple)),
                 "VersionInfoTextVersion": version,
                 "AppVersion": version,
                 "Platform": get_platform(),
                 "PythonVersion": sys.version[:3],
-                "URL": f"https://{domain.lower()}/",
-                "HTTPURL": f"http://{domain.lower()}/",
+                "URL": f"https://{DOMAIN}/",
+                "HTTPURL": f"http://{DOMAIN}/",
             }
             inno_template.close()
             inno_path = Path(
@@ -1220,7 +1220,7 @@ def setup():
                         if group.getAttribute("arch").startswith("Linux"):
                             python = "http://repo.roscidus.com/python/python"
                         else:
-                            python = f"http://{domain.lower()}/0install/python.xml"
+                            python = f"http://{DOMAIN}/0install/python.xml"
 
                         runner.setAttribute("interface", python)
                         runner.setAttribute(
@@ -1288,7 +1288,7 @@ def setup():
                     archive.setAttribute("extract", extract)
                     archive.setAttribute(
                         "href",
-                        f"http://{domain.lower()}/download.php?version={version}&"
+                        f"http://{DOMAIN}/download.php?version={version}&"
                         f"suffix=.tar.gz{folder}",
                     )
                     archive.setAttribute("size", str(os.stat(archive_path).st_size))
@@ -1361,7 +1361,7 @@ def setup():
 
                             icon.setAttribute(
                                 "href",
-                                f"http://{domain.lower()}/theme/icons/{subdir}{filename}.{ext}",
+                                f"http://{DOMAIN}/theme/icons/{subdir}{filename}.{ext}",
                             )
                             icon.setAttribute("type", mime_type)
                             entry_point.appendChild(icon)
@@ -1437,7 +1437,7 @@ def setup():
             if zeroinstall_version < "2.8":
                 zeroinstall_version = "2.8"
 
-            feed_uri = f"http://{domain.lower()}/0install/{name}.xml"
+            feed_uri = f"http://{DOMAIN}/0install/{name}.xml"
             dist_dir = Path(pydir, "dist", "0install", name + "-0install")
 
             for script, desc in scripts + [
@@ -1462,7 +1462,7 @@ def setup():
                     {
                         "NAME": bundlename,
                         "EXECUTABLE": script,
-                        "ID": ".".join(reversed(domain.split("."))) + "." + script,
+                        "ID": ".".join(reversed(DOMAIN.split("."))) + "." + script,
                     },
                 )
 
@@ -1528,7 +1528,7 @@ def setup():
 <plist version="1.0">
 <dict>
     <key>URL</key>
-    <string>https://{domain.lower()}/</string>
+    <string>https://{DOMAIN}/</string>
 </dict>
 </plist>
 """

--- a/util/0install_desktop.py
+++ b/util/0install_desktop.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import sys
 
-from DisplayCAL.meta import name as appname, domain, script2pywname
+from DisplayCAL.meta import name as appname, DOMAIN, script2pywname
 
 
 def zeroinstall_desktop(datadir="/usr/share"):
@@ -15,7 +15,7 @@ def zeroinstall_desktop(datadir="/usr/share"):
     appdir = os.path.join(datadir, "applications")
     if not os.path.isdir(appdir):
         os.makedirs(appdir)
-    feeduri = "http://%s/0install/%s.xml" % (domain.lower(), appname)
+    feeduri = f"http://{DOMAIN}/0install/{appname}.xml"
     for desktopfilename in glob(os.path.join("misc", "%s*.desktop" % appname.lower())):
         desktopbasename = os.path.basename(desktopfilename)
         scriptname = re.sub(r"\.desktop$", "", desktopbasename)

--- a/util/check_changelog_match.py
+++ b/util/check_changelog_match.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from DisplayCAL.meta import domain
+from DisplayCAL.meta import DOMAIN
 
 tplpth = os.path.join(os.path.dirname(__file__), "..", "misc", "README.template.html")
 with open(tplpth, "r") as tpl:
@@ -32,7 +32,7 @@ if chglog:
     )
     chglog = re.sub(
         re.compile(r'href="(#[^"]+)"', flags=re.I),
-        r'href="https://%s/\1"' % domain,
+        rf'href="https://{DOMAIN}/\1"',
         chglog,
     )
 

--- a/util/winversion.py
+++ b/util/winversion.py
@@ -12,7 +12,7 @@ sys.path.insert(
 )
 
 
-from DisplayCAL.meta import author, description, domain, name, version, version_tuple
+from DisplayCAL.meta import author, description, DOMAIN, name, version, version_tuple
 
 
 def mktempver(
@@ -22,7 +22,7 @@ def mktempver(
     tempver_str = version_template.read().decode(encoding, "replace") % {
         "filevers": str(version_tuple),
         "prodvers": str(version_tuple),
-        "CompanyName": domain,
+        "CompanyName": DOMAIN,
         "FileDescription": description_,
         "FileVersion": version,
         "InternalName": name_,


### PR DESCRIPTION
- Downloading and installing of argyll is working
- Displays and colorimeter are found
- Constant name "domain" changed to uppercase according to PEP8 and mostly because it is very confusing
- also used f-strings in modified code wherever possible
- #32 according to python3 documenation xmlparser object no longer has a 'returns_unicode' attribute: https://docs.python.org/3.9/library/pyexpat.html#xml.parsers.expat.ParserCreate
- Dict keys of win32api.GetMonitorInfo return are no bytestrings

- profiling and calibrating isn't working yet on win10