### PR TITLE
Misc py3 porting fixes

### DIFF
--- a/DisplayCAL/ICCProfile.py
+++ b/DisplayCAL/ICCProfile.py
@@ -1978,7 +1978,7 @@ def _colord_get_display_profile(display_no=0, path_only=False, use_cache=True):
             xrandr_name = display.get("xrandr_name")
             if xrandr_name:
                 edid = {"monitor_name": xrandr_name}
-                device_ids = ["xrandr-" + xrandr_name]
+                device_ids = [f"xrandr-{xrandr_name.decode()}"]
             elif os.getenv("XDG_SESSION_TYPE") == "wayland":
                 # Preliminary Wayland support under non-GNOME desktops.
                 # This still needs a lot of work.
@@ -1998,9 +1998,9 @@ def _colord_get_display_profile(display_no=0, path_only=False, use_cache=True):
                     # Device ID was not found, try next one
                     continue
                 except colord.CDError as exception:
-                    warnings.warn(str(exception, enc), Warning)
+                    warnings.warn(exception, Warning)
                 except colord.DBusException as exception:
-                    warnings.warn(str(exception, enc), Warning)
+                    warnings.warn(exception, Warning)
                 else:
                     if profile_path:
                         if "hash" in edid:

--- a/DisplayCAL/colord.py
+++ b/DisplayCAL/colord.py
@@ -250,7 +250,7 @@ def get_devices_by_kind(kind):
     if not isinstance(Colord, DBusObject):
         return []
     return [
-        Device(str(object_path, "UTF-8"))
+        Device(object_path)
         for object_path in Colord.get_devices_by_kind(kind)
     ]
 

--- a/DisplayCAL/util_x.py
+++ b/DisplayCAL/util_x.py
@@ -9,7 +9,7 @@ def get_display(display_name=None):
     if not display_name:
         display_name = (os.getenv("DISPLAY", ":0.0")).encode("utf-8")
     display_parts = display_name.split(b":")
-    hostname = display_parts[0]
+    hostname = display_parts[0].decode()
     display, screen = 0, 0
     if len(display_parts) > 1:
         try:

--- a/DisplayCAL/xrandr.py
+++ b/DisplayCAL/xrandr.py
@@ -99,7 +99,7 @@ class XDisplay(object):
         self.close()
 
     def open(self):
-        self.display = libx11.XOpenDisplay(self.name)
+        self.display = libx11.XOpenDisplay(self.name.encode())
         if not self.display:
             raise ValueError("Invalid X display %r" % self.name)
 


### PR DESCRIPTION
I only changed the str(Exception) where I encountered it as an issue,
but it's probably a hint that the other places it's done should also be
changed. (if you want to look at that...)

Most of this is a fallback case for if EDID wasn't successfully
extracted, so it's probably rarely used. And I'm not convinced the
fallback will ever work anyway, or at least "xrandr-DisplayPort-0"
didn't match against any outputs on my system...