### PR TITLE
DisplayCAL/wxfixes.py: convert float to int for calling wxPython's Sc…

### DIFF
--- a/DisplayCAL/wxfixes.py
+++ b/DisplayCAL/wxfixes.py
@@ -1146,7 +1146,7 @@ class ScrolledWindow(wx._ScrolledWindow):
         # if we need to adjust
         if new_vs_x != -1 or new_vs_y != -1:
             # print "%s: (%s, %s)" % (self.GetName(), new_vs_x, new_vs_y)
-            self.Scroll(new_vs_x, new_vs_y)
+            self.Scroll(int(new_vs_x), int(new_vs_y))
 
 
 wx.ScrolledWindow = ScrolledWindow


### PR DESCRIPTION
…roll(self, int, int) correctly. This fixes a crash on Archlinux partially. There is the exact same problem (with the same code snippets) in displaycal_venv/lib/python3.10/site-packages/wx/lib/scrolledpanel.py . These other use cases that will need fixing on wxPythons side. 

See related Archlinux bug report: 
https://bugs.archlinux.org/task/74781?project=5&string=displaycal

