### PR TITLE
Fix exception during 3DLUT generation

### DIFF
--- a/DisplayCAL/ICCProfile.py
+++ b/DisplayCAL/ICCProfile.py
@@ -4899,7 +4899,7 @@ class ProfileSequenceDescType(ICCProfileTag, list):
         """Add description structure of profile"""
         desc = {}
         desc.update(profile.device)
-        desc["tech"] = profile.tags.get("tech", "").ljust(4, "\0")[:4]
+        desc["tech"] = profile.tags.get("tech", b"").ljust(4, b"\0")[:4]
         for desc_type in ("dmnd", "dmdd"):
             if self.profile.version >= 4:
                 cls = MultiLocalizedUnicodeType

--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -1840,7 +1840,13 @@ class Producer(object):
         self.continue_next = continue_next
 
     def __call__(self, *args, **kwargs):
-        result = self.producer(*args, **kwargs)
+        try:
+            result = self.producer(*args, **kwargs)
+        except Exception as exception:
+            if debug:
+                messages = traceback.format_exception(exception)
+                print("[D] Worker raised an unhandled exception: \n" + "\n".join(messages))
+            raise
         if not self.continue_next and self.worker._progress_wnd:
             if hasattr(
                 self.worker.progress_wnd, "animbmp"

--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -4025,7 +4025,7 @@ END_DATA
         filename, ext = os.path.splitext(path)
         name = os.path.basename(filename)
 
-        if profile_in.profileClass == "link":
+        if profile_in.profileClass == b"link":
             link_basename = os.path.basename(profile_in.fileName)
             link_filename = os.path.join(cwd, link_basename)
             profile_in.write(link_filename)
@@ -4718,8 +4718,8 @@ END_DATA
                 logfiles.write("\n")
                 logfiles.write("Filling cLUT...\n")
                 profile_link = ICCP.ICCProfile()
-                profile_link.profileClass = "link"
-                profile_link.connectionColorSpace = "RGB"
+                profile_link.profileClass = b"link"
+                profile_link.connectionColorSpace = b"RGB"
                 profile_link.setDescription(name)
                 profile_link.setCopyright(getcfg("copyright"))
                 profile_link.tags.pseq = ICCP.ProfileSequenceDescType(

--- a/DisplayCAL/wxLUT3DFrame.py
+++ b/DisplayCAL/wxLUT3DFrame.py
@@ -930,7 +930,6 @@ class LUT3DMixin(object):
             # if exception.__class__.__name__ in dir(exceptions):
             #     raise
             if debug:
-                breakpoint()
                 messages = traceback.format_exception(exception)
                 print("[D] Worker raised exception: \n" + "\n".join(messages))
             return exception

--- a/DisplayCAL/wxLUT3DFrame.py
+++ b/DisplayCAL/wxLUT3DFrame.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import sys
+import traceback
 
 from DisplayCAL.wxaddons import CustomEvent
 
@@ -928,6 +929,10 @@ class LUT3DMixin(object):
         except Exception as exception:
             # if exception.__class__.__name__ in dir(exceptions):
             #     raise
+            if debug:
+                breakpoint()
+                messages = traceback.format_exception(exception)
+                print("[D] Worker raised exception: \n" + "\n".join(messages))
             return exception
         return True
 


### PR DESCRIPTION
This fixes the following error during 3DLUT generation:

![image](https://user-images.githubusercontent.com/613594/192149496-1a798a96-aa10-422f-86fa-5ba7525111bc.png)

```
ljust() argument 2 must be a byte string of length 1, not str
```

I also added a few tracebacks when DisplayCAL is run in verbose mode with `-d1`, so that exceptions that happen in subprocesses like this one can be more easily diagnosed in the future.