### PR TITLE
Change a view object to a list object

### DIFF
--- a/DisplayCAL/ICCProfile.py
+++ b/DisplayCAL/ICCProfile.py
@@ -4796,7 +4796,7 @@ class MultiLocalizedUnicodeType(ICCProfileTag, AODict):  # ICC v4
                 return list(self["en"].values())[0]
             return ""
         elif len(self):
-            return list(self.values())[0].values()[0]
+            return list(list(self.values())[0].values())[0]
         else:
             return ""
 


### PR DESCRIPTION
Hi [eoyilmaz](https://github.com/eoyilmaz/displaycal-py3/commits?author=eoyilmaz),

Thanks a lot for your great job of displaycal-py3. I encoutered with the below TypeError after I built the displaycal-py3 and I just gave a minor tinkering :-P

`Traceback (most recent call last):                                           │
│   File "/home/znd/.local/lib/python3.10/site-packages/wx/core.py", line      │
│ 3427, in <lambda>                                                            │
│     lambda event: event.callable(*event.args, **event.kw) )                  │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/display_cal.py",   │
│ line 19458, in setup_frame                                                   │
│     app.frame = MainFrame(self.worker)                                       │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/display_cal.py",   │
│ line 1877, in __init__                                                       │
│     self.update_controls(update_ccmx_items=False)                            │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/display_cal.py",   │
│ line 5321, in update_controls                                                │
│     self.mr_set_filebrowse_paths()                                           │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/wxReportFrame.py", │
│ line 711, in mr_set_filebrowse_paths                                         │
│     self.set_profile_ctrl_path(which)                                        │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/wxReportFrame.py", │
│ line 612, in set_profile_ctrl_path                                           │
│     getattr(self, "%s_profile_ctrl" % which).SetPath(                        │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/wxwindows.py",     │
│ line 3289, in SetPath                                                        │
│     self.SetValue(path, 0, clear_on_empty_value=True)                        │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/wxwindows.py",     │
│ line 3283, in SetValue                                                       │
│     self.textControl.Append(self.GetName(value))                             │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/wxwindows.py",     │
│ line 3202, in GetName                                                        │
│     name = profile.getDescription()                                          │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/ICCProfile.py",    │
│ line 7271, in getDescription                                                 │
│     return str(self.tags.get("desc", ""))                                    │
│   File                                                                       │
│ "/home/znd/.local/lib/python3.10/site-packages/DisplayCAL/ICCProfile.py",    │
│ line 4796, in __str__                                                        │
│     return list(self.values())[0].values()[0]                                │
│ TypeError: 'dict_values' object is not subscriptable                         │
└───────────────────────────────────────────────────────────`