### PR TITLE
fix deprecated "codeset" in gettext.translation() for python 3.11

### DIFF
--- a/DisplayCAL/defaultpaths.py
+++ b/DisplayCAL/defaultpaths.py
@@ -229,9 +229,14 @@ else:
                         locale_dir = path
                         break
 
+            # codeset is deprecated with python 3.11
             try:
                 obj.translation = gettext.translation(
                     obj.GETTEXT_PACKAGE, locale_dir, codeset="UTF-8"
+                )
+            except TypeError:
+                obj.translation = gettext.translation(
+                    obj.GETTEXT_PACKAGE, locale_dir
                 )
             except IOError as exception:
                 print("XDG:", exception)


### PR DESCRIPTION
`codeset` in `gettext` is deprecated with python 3.11.

The proposed commit additionally ensures backward compatibility with older versions.