### PR TITLE
DisplayCAL/defaultpaths.py: fix exception handling for gettext

### DIFF
--- a/DisplayCAL/defaultpaths.py
+++ b/DisplayCAL/defaultpaths.py
@@ -232,15 +232,17 @@ else:
             # codeset is deprecated with python 3.11
             try:
                 obj.translation = gettext.translation(
-                    obj.GETTEXT_PACKAGE, locale_dir, codeset="UTF-8"
+                    obj.GETTEXT_PACKAGE, locale_dir, codeset="UTF-8",
+                    fallback=True
                 )
             except TypeError:
                 obj.translation = gettext.translation(
-                    obj.GETTEXT_PACKAGE, locale_dir
+                    obj.GETTEXT_PACKAGE, locale_dir, fallback=True
                 )
-            except IOError as exception:
-                print("XDG:", exception)
-                obj.translation = gettext.NullTranslations()
+
+            if obj.translation._charset is None:
+                print("XDG: unable to find locale for domain",
+                      obj.GETTEXT_PACKAGE)
                 return False
             return True
 


### PR DESCRIPTION
f2ea3f28a8a170810af53b1501d5f505f9b4390d introduced support for python 3.11 by wrapping `gettext.translation()` with deprecated `codeset` into a try-except statement.

While it does solve the problem with backward compatibility, users of python 3.11 without locales will not be able to proceed due to lacking exception handlers for this case.

Use of `fallback` ensures that `gettext.NullTranslations()` will return in case of failed attempt to get locales, just like it used to be done in the dedicated exception handler.

---

Off the record: it seems I messed up again. According to python's docs, `fallback` is present at least since version 3.5.
As for the removed exception, its particulars should be handled by `gettext.translation()` with `fallback` set to True.

```python
def translation(domain, localedir=None, languages=None,
                class_=None, fallback=False):
    if class_ is None:
        class_ = GNUTranslations
    mofiles = find(domain, localedir, languages, all=True)
    if not mofiles:
        if fallback:
            return NullTranslations()
        from errno import ENOENT
        raise FileNotFoundError(ENOENT,
                                'No translation file found for domain', domain)
```

I chose to use `fallback` to avoid further complexity by writing another try-catch statement or even nesting it.