### PR TITLE
bytes-string comparison fix when reading .ti3 files

### DIFF
--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -13631,7 +13631,7 @@ usage: spotread [-options] [logfile]
                 if ext.lower() != ".ti1":
                     ti3_lines = [line.strip() for line in ti3]
                     ti3.close()
-                    if "CTI3" not in ti3_lines:
+                    if b"CTI3" not in ti3_lines:
                         return (
                             Error(
                                 lang.getstr(


### PR DESCRIPTION
I've been receiving *The testchart file example.icc is invalid* message at the end of calibration process. The reason was failing comparison of a bytes object read from a .ti3 file (the file was opened as "rb") with a string. This patch fixes it.

I think this is not the only place where strings and bytes are used incorrectly, because I see `TypeError: TypeError('cannot use a string pattern on a bytes-like object')` several times in the console output, but the calibration and profiling seems to finish correctly. I have not investigated those.