### PR TITLE
fix eoyilmaz/displaycal-py3#231

### DIFF
--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -6584,7 +6584,7 @@ while 1:
     if os.path.isfile(okfilename):
         try:
             os.remove(okfilename)
-        except OSError, e:
+        except OSError:
             pass
         else:
             break
@@ -6625,7 +6625,7 @@ while 1:
                     waitfile.write("#!/usr/bin/env python3\n")
                     waitfile.write(pythonscript)
                 os.chmod(waitfilename, 0o755)
-                args[index] += '"%s" ./%s' % (
+                args[index] += '%s ./%s' % (
                     strtr(safe_str(python), {'"': r"\"", "$": r"\$"}),
                     os.path.basename(waitfilename),
                 )


### PR DESCRIPTION
This PR fixes 2 bugs:
1. `dispread` passes the -C argument to the shell. Bash and zsh do not interpret the command correctly if `/usr/bin/env python` is wrapped in extra quotes. Fixing this reveals the second bug:
2. The Python script that is written to the `waitfile` contains Python 2 syntax that no longer works in Python 3 (`except OSError, e:`). I suppose this was missed due to the script being wrapped in quotes and therefore ignored by the linter. Since the exception object is not used in the except block, `, e` can just be discarded.

With these two minor changes, using DaVinci Resolve as a pattern generator works again. Tested on Fedora 37 with DisplayCAL running in a Python 3.10.10 virtual environment.