### PR TITLE
Fix appdata to validate for flathub

### DIFF
--- a/misc/net.displaycal.DisplayCAL.appdata.xml
+++ b/misc/net.displaycal.DisplayCAL.appdata.xml
@@ -26,6 +26,7 @@
             <caption>Interactive display adjustment</caption>
         </screenshot>
     </screenshots>
+    <content_rating type="oars-1.1" />
     <url type="homepage">${URL}</url>
     <url type="bugtracker">${URL}issues/</url>
     <url type="help">${URL}#toc</url>


### PR DESCRIPTION
- Issue #232

I had this patch lingering from the Python 2.7 based flatpak.

This make the appstream file validate for flathub. It's not specific to flathub so it's safe anywhere.