### PR TITLE
updated workflow to accommodate new branch restrictions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,9 @@
 name: Tests
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, unlabeled]
+    branches:
+      - develop
 
 jobs:
   build:


### PR DESCRIPTION
even so a developer hasn't activated workflows in his/her repository, this will trigger an action on eoyilmaz/displaycal-py3 that runs all tests against the submitted code
push is no longer needed, because of branch protection