### PR TITLE
allow py2app to build a MacOS app

### DIFF
--- a/DisplayCAL/setup.py
+++ b/DisplayCAL/setup.py
@@ -308,7 +308,7 @@ def create_app_symlinks(dist_dir, scripts):
                     tgt = os.path.join(toolcontents, entry, subentry)
                     if subentry == "main.py":
                         # py2app
-                        with open(src, "rb") as main_in:
+                        with open(src, "r") as main_in:
                             py = main_in.read()
                         py = py.replace("main()", "main(%r)" % script[len(name) + 1:])
                         with open(tgt, "wb") as main_out:
@@ -478,11 +478,11 @@ def setup():
             pass
         try:
             import setuptools
-            from setuptools import setup, Extension
+            from setuptools import setup, Extension, find_packages
 
             setuptools = True
             print("using setuptools")
-            current_findall = setuptools.findall
+            current_findall = find_packages
         except ImportError:
             pass
     else:
@@ -1624,38 +1624,40 @@ setup(ext_modules=[Extension("{name}.lib{bits}.RealDisplaySizeMM", sources={sour
         if dry_run or help:
             return
 
-        if do_py2app:
-            frameworks_dir = os.path.join(
-                dist_dir, name + ".app", "Contents", "Frameworks"
-            )
-            lib_dynload_dir = os.path.join(
-                dist_dir,
-                name + ".app",
-                "Contents",
-                "Resources",
-                "lib",
-                "python%s.%s" % sys.version_info[:2],
-                "lib-dynload",
-            )
-            # Fix Pillow (PIL) dylibs not being included
-            pil_dylibs = os.path.join(lib_dynload_dir, "PIL", ".dylibs")
-            if not os.path.isdir(pil_dylibs):
-                import PIL
+            # if do_py2app:
+            #     frameworks_dir = os.path.join(
+            #         dist_dir, name + ".app", "Contents", "Frameworks"
+            #     )
+            #     lib_dynload_dir = os.path.join(
+            #         dist_dir,
+            #         name + ".app",
+            #         "Contents",
+            #         "Resources",
+            #         "lib",
+            #         "python%s.%s" % sys.version_info[:2],
+            #         "lib-dynload",
+            #     )
+            #     # Fix Pillow (PIL) dylibs not being included
+            #     pil_dylibs = os.path.join(lib_dynload_dir, "PIL", ".dylibs")
+            #     if not os.path.isdir(pil_dylibs):
+            #         import PIL
 
-                pil_installed_dylibs = os.path.join(
-                    os.path.dirname(PIL.__file__), ".dylibs"
-                )
-                print("Copying", pil_installed_dylibs, "->", pil_dylibs)
-                shutil.copytree(pil_installed_dylibs, pil_dylibs)
-                for entry in os.listdir(pil_dylibs):
-                    print(os.path.join(pil_dylibs, entry))
-                # Remove wrongly included frameworks
-                dylibs_entries = os.listdir(pil_installed_dylibs)
-                for entry in os.listdir(frameworks_dir):
-                    if entry in dylibs_entries:
-                        dylib = os.path.join(frameworks_dir, entry)
-                        print("Removing", dylib)
-                        os.remove(dylib)
+            #         pil_installed_dylibs = os.path.join(
+            #             os.path.dirname(PIL.__file__), ".dylibs"
+            #         )
+            #         print("Copying", pil_installed_dylibs, "->", pil_dylibs)
+            #         shutil.copytree(pil_installed_dylibs, pil_dylibs)
+            #         for entry in os.listdir(pil_dylibs):
+            #             print(os.path.join(pil_dylibs, entry))
+            #         # Remove wrongly included frameworks
+            #         dylibs_entries = os.listdir(pil_installed_dylibs)
+            #         print("frameworks_dir", frameworks_dir)
+            #         for entry in os.listdir(frameworks_dir):
+            #             if entry in dylibs_entries:
+            #                 dylib = os.path.join(frameworks_dir, entry)
+            #                 print("Removing", dylib)
+            #                 os.remove(dylib)
+
             import wx
 
             if wx.VERSION >= (4,):

--- a/DisplayCAL/setup.py
+++ b/DisplayCAL/setup.py
@@ -1624,40 +1624,6 @@ setup(ext_modules=[Extension("{name}.lib{bits}.RealDisplaySizeMM", sources={sour
         if dry_run or help:
             return
 
-            # if do_py2app:
-            #     frameworks_dir = os.path.join(
-            #         dist_dir, name + ".app", "Contents", "Frameworks"
-            #     )
-            #     lib_dynload_dir = os.path.join(
-            #         dist_dir,
-            #         name + ".app",
-            #         "Contents",
-            #         "Resources",
-            #         "lib",
-            #         "python%s.%s" % sys.version_info[:2],
-            #         "lib-dynload",
-            #     )
-            #     # Fix Pillow (PIL) dylibs not being included
-            #     pil_dylibs = os.path.join(lib_dynload_dir, "PIL", ".dylibs")
-            #     if not os.path.isdir(pil_dylibs):
-            #         import PIL
-
-            #         pil_installed_dylibs = os.path.join(
-            #             os.path.dirname(PIL.__file__), ".dylibs"
-            #         )
-            #         print("Copying", pil_installed_dylibs, "->", pil_dylibs)
-            #         shutil.copytree(pil_installed_dylibs, pil_dylibs)
-            #         for entry in os.listdir(pil_dylibs):
-            #             print(os.path.join(pil_dylibs, entry))
-            #         # Remove wrongly included frameworks
-            #         dylibs_entries = os.listdir(pil_installed_dylibs)
-            #         print("frameworks_dir", frameworks_dir)
-            #         for entry in os.listdir(frameworks_dir):
-            #             if entry in dylibs_entries:
-            #                 dylib = os.path.join(frameworks_dir, entry)
-            #                 print("Removing", dylib)
-            #                 os.remove(dylib)
-
             import wx
 
             if wx.VERSION >= (4,):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,5 @@ pytest-xdist
 snowballstemmer
 twine
 yappi
+py2app
+wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=DisplayCAL
 version=attr: DisplayCAL.VERSION
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 
 [options]
 packages = find:


### PR DESCRIPTION
I tried to package DisplayCal for Mac with `py2app`, however I encountered several errors including #214.

I'm not a Python developer, but I tried my best to fix the errors. In the end, I successfully packaged a working DisplayCal.app (arm64). Not only that, but I transferred it to another similar MacBook, and it worked there just fine. Except that I had to add like 10 security exceptions in the FileVault since the sub-apps aren't signed by a valid certificate 😅.

Let me know if there's anything that I should change.

To test, you can run `python3 setup.py py2app`. 
Note that I added `py2app` and `wheel` to `requirements-dev.txt`, make sure to install them before running `py2app`.

After fixing the errors, I expect the next steps would be:
- Fix FileVault security warnings (certificate signing? user script to set attributes?)
- Github Actions workflow to build Mac Arm and x86 packages

P.S. I had some issues getting Black and Flake8 to work together. Black would add some whitespace that Flake8 complained about. Since I don't know how to make them work together properly, I excluded formatting changes.