### PR TITLE
Colorimeter correction workflow improvements

### DIFF
--- a/DisplayCAL/CGATS.py
+++ b/DisplayCAL/CGATS.py
@@ -617,7 +617,10 @@ class CGATS(dict):
                 elif isinstance(value, (float, int, bytes)):
                     if key not in ("NUMBER_OF_FIELDS", "NUMBER_OF_SETS"):
                         if isinstance(key, int):
-                            result.append(bytes(str(value), "utf-8"))
+                            if isinstance(value, bytes):
+                                result.append(value)
+                            else:
+                                result.append(bytes(str(value), "utf-8"))
                         else:
                             if "KEYWORDS" in self and key in list(
                                 self["KEYWORDS"].values()

--- a/DisplayCAL/argyll_instruments.py
+++ b/DisplayCAL/argyll_instruments.py
@@ -200,7 +200,7 @@ instruments = {
         "sensor_cal": True,
         "skip_sensor_cal": True,
         "integration_time": [9.2, 3.9],  # Still just using i1 Pro values
-        "refresh": False,
+        "refresh": True,
     },
     "ColorHug": {
         "usb_ids": [

--- a/DisplayCAL/argyll_instruments.py
+++ b/DisplayCAL/argyll_instruments.py
@@ -191,6 +191,17 @@ instruments = {
         "integration_time": [9.2, 3.9],  # Using i1 Pro values
         "refresh": True,
     },
+    "i1 Pro 3": {
+        "usb_ids": [{"vid": 0x0765, "pid": 0x6009, "hid": False}],
+        "spectral": True,
+        "adaptive_mode": True,
+        "highres_mode": True,
+        "projector_mode": False,
+        "sensor_cal": True,
+        "skip_sensor_cal": True,
+        "integration_time": [9.2, 3.9],  # Still just using i1 Pro values
+        "refresh": False,
+    },
     "ColorHug": {
         "usb_ids": [
             {"vid": 0x04D8, "pid": 0xF8DA, "hid": True},

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -13218,12 +13218,12 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                         display = (
                             meta.get("EDID_model", meta.get("EDID_model_id", {}))
                             .get("value", "")
-                            .encode("UTF-7")
+                            .encode("utf-8")
                         )
                         manufacturer = (
                             meta.get("EDID_manufacturer", {})
                             .get("value", "")
-                            .encode("UTF-7")
+                            .encode("utf-8")
                         )
                         cgats.ARGYLL_COLPROF_ARGS.add_data(
                             '-M "%s" -A "%s"' % (display, manufacturer)
@@ -13824,7 +13824,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     b'\nOBSERVER "%s"\\1' % observer.replace(b"\\", b"\\\\"),
                     cgats,
                 )
-            if reference_observer.encode("utf-8") and not re.search(
+            if reference_observer and not re.search(
                 rb'\nREFERENCE_OBSERVER\s+".+?"\n', cgats
             ):
                 # By default, CCMX/CCSS files don't contain observer
@@ -14994,15 +14994,6 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             if debug:
                 print("[D] display_ctrl_handler -> lut_viewer_load_lut END")
         self.update_use_video_lut()
-        # Special case: Resolve. Needs a minimum display update delay of
-        # atleast 600 ms for repeatable measurements. This is a Resolve
-        # issue. There seem to be quite a few bugs that were introduced in
-        # Resolve via the version 10.1.x to 11.x transition.
-        is_resolve = config.get_display_name() == "Resolve"
-        update_delay_ctrls = setcfg_cond(
-            is_resolve, "measure.min_display_update_delay_ms", 1000
-        )
-        setcfg_cond(is_resolve, "measure.override_min_display_update_delay_ms", 1)
         # Enable 3D LUT tab for virtual displays & eeColor
         enable_3dlut_tab = (
             config.is_virtual_display() or config.get_display_name() == "SII REPEATER"
@@ -15010,10 +15001,6 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
         setcfg_cond(
             enable_3dlut_tab, "3dlut.tab.enable", 1, True, not getcfg("3dlut.create")
         )
-        if update_delay_ctrls:
-            override = bool(getcfg("measure.override_min_display_update_delay_ms"))
-            getattr(self, "override_min_display_update_delay_ms").SetValue(override)
-            self.update_display_delay_ctrl("min_display_update_delay_ms", override)
         self.update_drift_compensation_ctrls()
         self.show_display_delay_ctrls()
         self.show_ffp_ctrls()

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -10985,7 +10985,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             except Exception as exception:
                 wx.CallAfter(show_result_dialog, exception, self)
             else:
-                if cgats.queryv1("INSTRUMENT_TYPE_SPECTRAL") == "YES":
+                if cgats.queryv1("INSTRUMENT_TYPE_SPECTRAL").decode("utf-8") == "YES":
                     setcfg("last_reference_ti3_path", cgats.filename)
                 else:
                     setcfg("last_colorimeter_ti3_path", cgats.filename)

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -13515,6 +13515,10 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     boxsizer.Add((1, 8))
                 if not config.is_virtual_display():
                     display = self.worker.get_display_name(False, True, False)
+                # "display" is never assigned anything from line 13402 and remains a NoneType, which throws an error in the following "dlg.display_txt_ctrl"
+                # It looks like another byte vs. string issue all the way back in how the ARGYLL_COLPROF_ARGS section is written into the reference.ti3
+                # So for now, this puts the short name of virtual displays into the dialog box so the process can continue
+                else: display = self.worker.get_display_name_short()
                 dlg.display_txt_ctrl = wx.TextCtrl(dlg, -1, display, size=(400, -1))
                 boxsizer.Add(
                     dlg.display_txt_ctrl,

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -10985,7 +10985,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             except Exception as exception:
                 wx.CallAfter(show_result_dialog, exception, self)
             else:
-                if cgats.queryv1("INSTRUMENT_TYPE_SPECTRAL").decode("utf-8") == "YES":
+                if cgats.queryv1("INSTRUMENT_TYPE_SPECTRAL") == b"YES":
                     setcfg("last_reference_ti3_path", cgats.filename)
                 else:
                     setcfg("last_colorimeter_ti3_path", cgats.filename)
@@ -13218,12 +13218,12 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                         display = (
                             meta.get("EDID_model", meta.get("EDID_model_id", {}))
                             .get("value", "")
-                            .encode("utf-8")
+                            .encode("utf-7")
                         )
                         manufacturer = (
                             meta.get("EDID_manufacturer", {})
                             .get("value", "")
-                            .encode("utf-8")
+                            .encode("utf-7")
                         )
                         cgats.ARGYLL_COLPROF_ARGS.add_data(
                             '-M "%s" -A "%s"' % (display, manufacturer)
@@ -13511,7 +13511,9 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             dlg.sizer3.Add(boxsizer, 1, flag=wx.TOP | wx.EXPAND, border=12)
             if sys.platform not in ("darwin", "win32"):
                 boxsizer.Add((1, 8))
-            if not display: display = self.worker.get_display_name(False, True, False) # protects from an improperly formatted display name in the ref.ti3
+            if not display:
+                # protects from an improperly formatted display name in the ref.ti3
+                display = self.worker.get_display_name(False, True, False)
             dlg.display_txt_ctrl = wx.TextCtrl(dlg, -1, display, size=(400, -1))
             boxsizer.Add(
                 dlg.display_txt_ctrl,

--- a/DisplayCAL/pnp.ids
+++ b/DisplayCAL/pnp.ids
@@ -1,18 +1,14 @@
-3GV	VR Technology Holdings Limited
-3NO	Shenzhen three Connaught Information Technology Co., Ltd. (3nod Group)
+?	Unknown
 AAA	Avolites Ltd
-AAC	AcerView
 AAE	Anatek Electronics Inc.
 AAM	Aava Mobile Oy
 AAN	AAEON Technology Inc.
 AAT	Ann Arbor Technologies
-AAV	Aava Mobile Oy
 ABA	ABBAHOME INC.
 ABC	AboCom System Inc.
 ABD	Allen Bradley Company
 ABE	Alcatel Bell
 ABO	D-Link Systems Inc
-ABP	Advansys
 ABS	Abaco Systems, Inc.
 ABT	Anchor Bay Technologies, Inc.
 ABV	Advanced Research Technology
@@ -87,6 +83,7 @@ AKI	AKIA Corporation
 AKL	AMiT Ltd
 AKM	Asahi Kasei Microsystems Company Ltd
 AKP	Atom Komplex Prylad
+AKR	Anker Innovations Limited
 AKY	Askey Computer Corporation
 ALA	Alacron Inc
 ALC	Altec Corporation
@@ -101,7 +98,7 @@ ALL	Alliance Semiconductor Corporation
 ALM	Acutec Ltd.
 ALN	Alana Technologies
 ALO	Algolith Inc.
-ALP	Alps Electric Company Ltd
+ALP	ALPS ALPINE CO., LTD.
 ALR	Advanced Logic
 ALS	Avance Logic Inc
 ALT	Altra
@@ -110,18 +107,16 @@ ALX	ALEXON Co.,Ltd.
 AMA	Asia Microelectronic Development Inc
 AMB	Ambient Technologies, Inc.
 AMC	Attachmate Corporation
-AMD	AMD
+AMD	Amdek Corporation
 AMI	American Megatrends Inc
 AML	Anderson Multimedia Communications (HK) Limited
 AMN	Amimon LTD.
 AMO	Amino Technologies PLC and Amino Communications Limited
-AMP	Ampere Computing
+AMP	AMP Inc
 AMR	AmTRAN Technology Co., Ltd.
 AMS	ARMSTEL, Inc.
 AMT	AMT International Industry
-AMW	AMW
 AMX	AMX LLC
-AMZ	Amazon Corporation
 ANA	Anakron
 ANC	Ancot
 AND	Adtran Inc
@@ -137,23 +132,22 @@ ANV	Beijing ANTVR Technology Co., Ltd.
 ANW	Analog Way SAS
 ANX	Acer Netxus Inc
 AOA	AOpen Inc.
-AOC	AOC
 AOE	Advanced Optics Electronics, Inc.
+AOM	Atomos
 AOL	America OnLine
 AOT	Alcatel
-APA	Adaptec
 APC	American Power Conversion
 APD	AppliAdata
-APE	Alpine Electronics, Inc.
+APE	ALPS ALPINE CO., LTD.
 APG	Horner Electric Inc
 API	A Plus Info Corporation
 APL	Aplicom Oy
-APM	Applied Micro Circuits Corporation
+APM	Applied Memory Tech
 APN	Appian Tech Inc
 APP	Apple Computer Inc
 APR	Aprilia s.p.a.
 APS	Autologic Inc
-APT	Aptina Imaging Corporation
+APT	Audio Processing Technology  Ltd
 APV	A+V Link
 APX	AP Designs Ltd
 ARC	Alta Research Corporation
@@ -163,7 +157,7 @@ ARG	Argus Electronics Co., LTD
 ARI	Argosy Research Inc
 ARK	Ark Logic Inc
 ARL	Arlotto Comnet Inc
-ARM	ARM Ltd.
+ARM	Arima
 ARO	Poso International B.V.
 ARR	ARRIS Group, Inc.
 ARS	Arescom Inc
@@ -179,7 +173,7 @@ ASM	ASEM S.p.A.
 ASN	Asante Tech Inc
 ASP	ASP Microelectronics Ltd
 AST	AST Research Inc
-ASU	ASUS
+ASU	Asuscom Network Inc
 ASX	AudioScience
 ASY	Rockwell Collins / Airshow Systems
 ATA	Allied Telesyn International (Asia) Pte Ltd
@@ -191,19 +185,20 @@ ATI	Allied Telesis KK
 ATJ	ArchiTek Corporation
 ATK	Allied Telesyn Int'l
 ATL	Arcus Technology Ltd
-ATM	Atmel
+ATM	ATM Ltd
 ATN	Athena Smartcard Solutions Ltd.
 ATO	ASTRO DESIGN, INC.
 ATP	Alpha-Top Corporation
 ATT	AT&T
+ATU	Avocor Technologies USA, Inc
 ATV	Office Depot, Inc.
 ATX	Athenix Corporation
+AUD	AudioControl
 AUG	August Home, Inc.
-AUI	Alps Electric Inc
-AUO	AU Optronics
+AUI	ALPS ALPINE CO., LTD.
 AUR	Aureal Semiconductor
 AUS	ASUSTek COMPUTER INC
-AUT	AuthenTec
+AUT	Autotime Corporation
 AUV	Auvidea GmbH
 AVA	Avaya Communication
 AVC	Auravision Corporation
@@ -249,6 +244,7 @@ BBX	Black Box Corporation
 BCC	Beaver Computer Corporaton
 BCD	Barco GmbH
 BCI	Broadata Communications Inc.
+BCK	Beck GmbH & Co. Elektronik Bauelemente KG
 BCM	Broadcom
 BCQ	Deutsche Telekom Berkom GmbH
 BCS	Booria CAD/CAM systems
@@ -266,35 +262,35 @@ BGT	Budzetron Inc
 BHZ	BitHeadz, Inc.
 BIA	Biamp Systems Corporation
 BIC	Big Island Communications
+BIG	Bigscreen, Inc.
 BII	Boeckeler Instruments Inc
 BIL	Billion Electric Company Ltd
 BIO	BioLink Technologies International, Inc.
 BIT	Bit 3 Computer
+BLD	BILD INNOVATIVE TECHNOLOGY LLC
 BLI	Busicom
 BLN	BioLink Technologies
 BLP	Bloomberg L.P.
 BMD	Blackmagic Design
 BMI	Benson Medical Instruments Company
 BML	BIOMED Lab
-BMM	BMM
 BMS	BIOMEDISYS
 BNE	Bull AB
 BNK	Banksia Tech Pty Ltd
 BNO	Bang & Olufsen
-BNQ	BenQ Corporation
 BNS	Boulder Nonlinear Systems
 BOB	Rainy Orchard
 BOE	BOE
 BOI	NINGBO BOIGLE DIGITAL TECHNOLOGY CO.,LTD
-BOO	Coreboot Project
-BOS	Robert Bosch GmbH
+BOS	BOS
 BPD	Micro Solutions, Inc.
 BPS	Barco, N.V.
 BPU	Best Power
 BRA	Braemac Pty Ltd
-BRC	Broadcom Corporation
+BRC	BARC
 BRG	Bridge Information Co., Ltd
 BRI	Boca Research Inc
+BRL	Brainlab AG
 BRM	Braemar Inc
 BRO	BROTHER INDUSTRIES,LTD.
 BSE	Bose Corporation
@@ -311,7 +307,7 @@ BUF	Yasuhiko Shirai Melco Inc
 BUG	B.U.G., Inc.
 BUJ	ATI Tech Inc
 BUL	Bull
-BUR	Bernecker & Rainer Ind-Eletronik GmbH
+BUR	B&R Industrial Automation GmbH
 BUS	BusTek
 BUT	21ST CENTURY ENTERTAINMENT
 BWK	Bitworks Inc.
@@ -359,11 +355,11 @@ CEP	C-DAC
 CER	Ceronix
 CET	TEC CORPORATION
 CFG	Atlantis
+CFR	Meta View, Inc.
 CGA	Chunghwa Picture Tubes, LTD
 CGS	Chyron Corp
 CGT	congatec AG
 CHA	Chase Research PLC
-CHC	Chic Technology Corp.
 CHD	ChangHong Electric Co.,Ltd
 CHE	Acer Inc
 CHG	Sichuan Changhong Electric CO, LTD.
@@ -394,14 +390,15 @@ CLG	CoreLogic
 CLI	Cirrus Logic Inc
 CLM	CrystaLake Multimedia
 CLO	Clone Computers
+CLR	Clover Electronics
 CLT	automated computer control systems
 CLV	Clevo Company
 CLX	CardLogix
 CMC	CMC Ltd
 CMD	Colorado MicroDisplay, Inc.
 CMG	Chenming Mold Ind. Corp.
-CMH	COMHEAR, INC.
 CMI	C-Media Electronics
+CMK	Comark LLC
 CMM	Comtime GmbH
 CMN	Chimei Innolux Corporation
 CMO	Chi Mei Optoelectronics corp.
@@ -410,19 +407,19 @@ CMS	CompuMaster Srl
 CMX	Comex Electronics AB
 CNB	American Power Conversion
 CNC	Alvedon Computers Ltd
+CND	Micro-Star Int'l Co., Ltd.
 CNE	Cine-tal
 CNI	Connect Int'l A/S
 CNN	Canon Inc
 CNT	COINT Multimedia Systems
 COB	COBY Electronics Co., Ltd
 COD	CODAN Pty. Ltd.
-COG	Cogent
 COI	Codec Inc.
 COL	Rockwell Collins, Inc.
 COM	Comtrol Corporation
 CON	Contec Company Ltd
 COO	coolux GmbH
-COR	CoreOS, Inc
+COR	Corollary Inc
 COS	CoStar Corporation
 COT	Core Technology Inc
 COW	Polycow Productions
@@ -430,7 +427,7 @@ COX	Comrex
 CPC	Ciprico Inc
 CPD	CompuAdd
 CPI	Computer Peripherals Inc
-CPL	Capella Microsystems Inc.
+CPL	Compal Electronics Inc
 CPM	Capella Microsystems Inc.
 CPP	Compound Photonics
 CPQ	Compaq Computer Company
@@ -442,12 +439,14 @@ CRD	Cardinal Technical Inc
 CRE	Creative Labs Inc
 CRH	Contemporary Research Corp.
 CRI	Crio Inc.
-CRL	Creative Logic
+CRL	Creative Logic  
+CRM	CORSAIR MEMORY Inc.
 CRN	Cornerstone Imaging
 CRO	Extraordinary Technologies PTY Limited
 CRQ	Cirque Corporation
 CRS	Crescendo Communication Inc
 CRV	Cerevo Inc.
+CRW	Cammegh Limited
 CRX	Cyrix Corporation
 CSB	Transtex SA
 CSC	Crystal Semiconductor
@@ -459,6 +458,7 @@ CSM	Cosmic Engineering Inc.
 CSO	California Institute of Technology
 CSS	CSS Laboratories
 CST	CSTI Inc
+CSW	China Star Optoelectronics Technology Co., Ltd
 CTA	CoSystems Inc
 CTC	CTC Communication Development Company Ltd
 CTE	Chunghwa Telecom Co., Ltd.
@@ -527,7 +527,8 @@ DDT	Datadesk Technologies Inc
 DDV	Delta Information Systems, Inc
 DEC	Digital Equipment Corporation
 DEI	Deico Electronics
-DEL	Dell, Inc.
+DEL	Dell Inc.
+DEM	DemoPad Software Ltd
 DEN	Densitron Computers Ltd
 DEX	idex displays
 DFI	DFI
@@ -551,22 +552,26 @@ DIM	dPict Imaging, Inc.
 DIN	Daintelecom Co., Ltd
 DIS	Diseda S.A.
 DIT	Dragon Information Technology
-DJE	Capstone Visual Product Development
+DJE	Capstone Visua lProduct Development
 DJP	Maygay Machines, Ltd
 DKY	Datakey Inc
 DLB	Dolby Laboratories Inc.
 DLC	Diamond Lane Comm. Corporation
-DLG	Dialog Semiconductor PLC
+DLD	Delem
+DLG	Digital-Logic GmbH
 DLK	D-Link Systems Inc
-DLL	Dell, Inc.
+DLL	Dell Inc
+DLM	DLOGIC Ltd.
+DLO	Shenzhen Dlodlo Technologies Co., Ltd.
 DLT	Digitelec Informatique Park Cadera
 DMB	Digicom Systems Inc
 DMC	Dune Microsystems Corporation
+DMG	Monoprice.Inc
 DMM	Dimond Multimedia Systems Inc
 DMN	Dimension Engineering LLC
 DMO	Data Modul AG
 DMP	D&M Holdings Inc, Professional Business Company
-DMS	DMIST RESEARCH LTD
+DMS	DOME imaging systems
 DMT	Distributed Management Task Force, Inc. (DMTF)
 DMV	NDS Ltd
 DNA	DNA Enterprises, Inc.
@@ -596,18 +601,18 @@ DRI	Data Race Inc
 DRS	DRS Defense Solutions, LLC
 DSA	Display Solution AG
 DSD	DS Multimedia Pte Ltd
+DSG	Disguise Technologies
 DSI	Digitan Systems Inc
 DSJ	VR Technology Holdings Limited
 DSM	DSM Digital Services GmbH
 DSP	Domain Technology Inc
-DSU	Shenzhen DSO Microelectronics Co.,Ltd.
 DTA	DELTATEC
 DTC	DTC Tech Corporation
 DTE	Dimension Technologies, Inc.
 DTI	Diversified Technology, Inc.
 DTK	Dynax Electronics (HK) Ltd
 DTL	e-Net Inc
-DTN	Datang Telephone Co
+DTN	Datang  Telephone Co
 DTO	Deutsche Thomson OHG
 DTT	Design & Test Technology, Inc.
 DTX	Data Translation
@@ -621,12 +626,14 @@ DWE	Daewoo Electronics Company Ltd
 DXC	Digipronix Control Systems
 DXD	DECIMATOR DESIGN PTY LTD
 DXL	Dextera Labs Inc
+DXN	Dixon Technologies (India) Limited
 DXP	Data Expert Corporation
 DXS	Signet
 DYC	Dycam Inc
 DYM	Dymo-CoStar Corporation
 DYN	Askey Computer Corporation
 DYX	Dynax Electronics (HK) Ltd
+EAC	Emotiva Audio Corp. 
 EAG	ELTEC Elektronik AG
 EAS	Evans and Sutherland Computer
 EBH	Data Price Informatica
@@ -650,6 +657,7 @@ EDM	EDMI
 EDT	Emerging Display Technologies Corp
 EEE	ET&T Technology Company Ltd
 EEH	EEH Datalink GmbH
+EEI	ELARABY COMPANY FOR ENGINEERING INDUSTRIES
 EEP	E.E.P.D. GmbH
 EES	EE Solutions, Inc.
 EGA	Elgato Systems LLC
@@ -661,12 +669,12 @@ EHJ	Epson Research
 EHN	Enhansoft
 EIC	Eicon Technology Corporation
 EIN	Elegant Invention
-EIZ	Eizo
 EKA	MagTek Inc.
 EKC	Eastman Kodak Company
 EKS	EKSEN YAZILIM
-ELA	ELAN MICROELECTRONICS CORPORATION
+ELA	ELAD srl
 ELC	Electro Scientific Ind
+ELD	Express Luck, Inc.
 ELE	Elecom Company Ltd
 ELG	Elmeg GmbH Kommunikationstechnik
 ELI	Edsun Laboratories
@@ -685,6 +693,7 @@ EMG	EMG Consultants Inc
 EMI	Ex Machina Inc
 EMK	Emcore Corporation
 EMO	ELMO COMPANY, LIMITED
+EMR	ICC Intelligent Platforms GmbH
 EMU	Emulex Corporation
 ENC	Eizo Nanao Corporation
 END	ENIDAN Technologies Ltd
@@ -694,7 +703,7 @@ ENS	Ensoniq Corporation
 ENT	Enterprise Comm. & Computing Inc
 EON	Eon Instrumentation, Inc.
 EPC	Empac
-EPH	Epiphan Systems Inc.
+EPH	Epiphan Systems Inc. 
 EPI	Envision Peripherals, Inc
 EPN	EPiCON Inc.
 EPS	KEPS
@@ -707,7 +716,7 @@ ERP	Euraplan GmbH
 ERS	Eizo Rugged Solutions
 ERT	Escort Insturments Corporation
 ESA	Elbit Systems of America
-ESB	Esterline Belgium BVBA
+ESB	ScioTeq
 ESC	Eden Sistemas de Computacao S/A
 ESD	Ensemble Designs, Inc
 ESG	ELCON Systemtechnik GmbH
@@ -715,11 +724,12 @@ ESI	Extended Systems, Inc.
 ESK	ES&S
 ESL	Esterline Technologies
 ESN	eSATURNUS
-ESS	Everest Semiconductor Co., Ltd.
+ESS	ESS Technology Inc
 EST	Embedded Solution Technology
 ESY	E-Systems Inc
 ETC	Everton Technology Company Ltd
 ETD	ELAN MICROELECTRONICS CORPORATION
+ETG	Eizo Technologies GmbH
 ETH	Etherboot Project
 ETI	Eclipse Tech Inc
 ETK	eTEK Labs Inc.
@@ -729,8 +739,9 @@ ETT	E-Tech Inc
 EUT	Ericsson Mobile Networks B.V.
 EVE	Advanced Micro Peripherals Ltd
 EVI	eviateg GmbH
+EVP	EverPro Technologies Company Limited
 EVX	Everex
-EXA	Exar Corporation
+EXA	Exabyte
 EXC	Excession Audio
 EXI	Exide Electronics
 EXN	RGB Systems, Inc. dba Extron Electronics
@@ -748,12 +759,12 @@ FAR	Farallon Computing
 FBI	Interface Corporation
 FCB	Furukawa Electric Company Ltd
 FCG	First International Computer Ltd
-FCM	Funai
 FCS	Focus Enhancements, Inc.
 FDC	Future Domain
 FDD	Forth Dimension Displays Ltd
 FDI	Future Designs, Inc.
 FDT	Fujitsu Display Technologies Corp.
+FDX	Findex, Inc.
 FEC	FURUNO ELECTRIC CO., LTD.
 FEL	Fellowes & Questec
 FEN	Fen Systems Ltd.
@@ -769,10 +780,11 @@ FIN	Finecom Co., Ltd.
 FIR	Chaplet Systems Inc
 FIS	FLY-IT Simulators
 FIT	Feature Integration Technology Inc.
-FJC	Fujitsu Takamisawa Component Limited
+FJC	FCL COMPONENTS LIMITED
 FJS	Fujitsu Spain
 FJT	F.J. Tieman BV
 FLE	ADTI Media, Inc
+FLD	Flanders Scientific, Inc.
 FLI	Faroudja Laboratories
 FLY	Butterfly Communications
 FMA	Fast Multimedia AG
@@ -796,7 +808,7 @@ FRD	Freedom Scientific BLV
 FRE	Forvus Research Inc
 FRI	Fibernet Research Inc
 FRO	FARO Technologies
-FRS	Freescale, Inc
+FRS	South Mountain Technologies, LTD
 FSC	Future Systems Consulting KK
 FSI	Fore Systems Inc
 FST	Modesto PC Inc
@@ -810,6 +822,7 @@ FTR	Mediasonic
 FTS	FocalTech Systems Co., Ltd.
 FTW	MindTribe Product Engineering, Inc.
 FUJ	Fujitsu Ltd
+FUL	Fun Technology Innovation INC.
 FUN	sisel muhendislik
 FUS	Fujitsu Siemens Computers GmbH
 FVC	First Virtual Corporation
@@ -845,7 +858,6 @@ GFM	GFMesstechnik GmbH
 GFN	Gefen Inc.
 GGL	Google Inc.
 GGT	G2TOUCH KOREA
-GHS	Green Hills Software
 GIC	General Inst. Corporation
 GIM	Guillemont International
 GIP	GI Provision Ltd
@@ -864,7 +876,6 @@ GND	Gennum Corporation
 GNN	GN Nettest Inc
 GNZ	Gunze Ltd
 GOE	GOEPEL electronic GmbH
-GOO	Google, Inc.
 GPR	GoPro, Inc.
 GRA	Graphica Computer
 GRE	GOLD RAIN ENTERPRISES CORP.
@@ -874,23 +885,26 @@ GRV	Advanced Gravis
 GRY	Robert Gray Company
 GSB	NIPPONDENCHI CO,.LTD
 GSC	General Standards Corporation
-GSM	LG Electronics
+GSM	Goldstar Company Ltd
 GSN	Grandstream Networks, Inc.
 GST	Graphic SystemTechnology
 GSY	Grossenbacher Systeme AG
-GTC	G2touch Co., LTD
+GTC	Graphtec Corporation
 GTI	Goldtouch
 GTK	G-Tech Corporation
 GTM	Garnet System Company Ltd
 GTS	Geotest Marvin Test Systems Inc
 GTT	General Touch Technology Co., Ltd.
 GUD	Guntermann & Drunck GmbH
+GUP	GoUp Co.,Ltd
 GUZ	Guzik Technical Enterprises
 GVC	GVC Corporation
 GVL	Global Village Communication
+GVS	G.VISION
 GWI	GW Instruments
 GWK	Gateworks Corporation
 GWY	Gateway 2000
+GXL	Galaxy Microsystems Ltd.
 GZE	GUNZE Limited
 HAE	Haider electronics
 HAI	Haivision Systems Inc.
@@ -908,20 +922,19 @@ HDC	HardCom Elektronik & Datateknik
 HDI	HD-INFO d.o.o.
 HDV	Holografika kft.
 HEC	Hisense Electric Co., Ltd.
-HEI	Hyundai
 HEL	Hitachi Micro Systems Europe Ltd
 HER	Ascom Business Systems
 HET	HETEC Datensysteme GmbH
 HHC	HIRAKAWA HEWTECH CORP.
 HHI	Fraunhofer Heinrich-Hertz-Institute
+HHT	Hitevision Group
 HIB	Hibino Corporation
 HIC	Hitachi Information Technology Co., Ltd.
 HII	Harman International Industries, Inc
 HIK	Hikom Co., Ltd.
 HIL	Hilevel Technology
-HIM	Himax Technologies, Inc.
 HIQ	Kaohsiung Opto Electronics Americas, Inc.
-HIS	HiSilicon Technologies Co., Ltd.
+HIS	Hope Industrial Systems, Inc.
 HIT	Hitachi America Ltd
 HJI	Harris & Jeffries Inc
 HKA	HONKO MFG. CO., LTD.
@@ -931,6 +944,7 @@ HLG	China Hualu Group Co., Ltd.
 HMC	Hualon Microelectric Corporation
 HMK	hmk Daten-System-Technik BmbH
 HMX	HUMAX Co., Ltd.
+HNM	HONOR Device Co., Ltd.
 HNS	Hughes Network Systems
 HOB	HOB Electronic GmbH
 HOE	Hosiden Corporation
@@ -940,10 +954,10 @@ HPA	Zytor Communications
 HPC	Hewlett-Packard Co.
 HPD	Hewlett Packard
 HPE	Hewlett Packard Enterprise
-HPI	HP Inc.
+HPI	Headplay, Inc.
 HPK	HAMAMATSU PHOTONICS K.K.
 HPN	HP Inc.
-HPQ	Hewlett-Packard Company
+HPQ	Hewlett-Packard Co.
 HPR	H.P.R. Electronics GmbH
 HRC	Hercules
 HRE	Qingdao Haier Electronics Co., Ltd.
@@ -953,8 +967,8 @@ HRS	Harris Semiconductor
 HRT	HERCULES
 HSC	Hagiwara Sys-Com Company Ltd
 HSD	HannStar Display Corp
-HSL	Hansol
 HSM	AT&T Microelectronics
+HSN	Hansung Co., Ltd
 HSP	HannStar Display Corp
 HST	Horsent Technology Co., Ltd.
 HTC	Hitachi Ltd
@@ -970,10 +984,9 @@ HVR	HTC Corportation
 HWA	Harris Canada Inc
 HWC	DBA Hans Wedemeyer
 HWD	Highwater Designs Ltd
-HWP	Hewlett Packard Enterprise
+HWP	Hewlett Packard
 HWV	Huawei Technologies Co., Inc.
 HXM	Hexium Ltd.
-HXT	Guizhou Huaxintong Semiconductor Technology Co., Ltd
 HYC	Hypercope Gmbh Aachen
 HYD	Hydis Technologies.Co.,LTD
 HYL	Shanghai Chai Ming Huang Info&Tech Co, Ltd
@@ -988,7 +1001,7 @@ IAI	Integration Associates, Inc.
 IAT	IAT Germany GmbH
 IBC	Integrated Business Systems
 IBI	INBINE.CO.LTD
-IBM	IBM
+IBM	IBM Brasil
 IBP	IBP Instruments GmbH
 IBR	IBR GmbH
 ICA	ICA Inc
@@ -996,16 +1009,16 @@ ICC	BICC Data Networks Ltd
 ICD	ICD Inc
 ICE	IC Ensemble
 ICI	Infotek Communication Inc
-ICL	Fujitsu ICL
 ICM	Intracom SA
 ICN	Sanyo Icon
 ICO	Intel Corp
 ICP	ICP Electronics, Inc./iEi Technology Corp.
+ICR	Icron
 ICS	Integrated Circuit Systems
 ICV	Inside Contactless
 ICX	ICCC A/S
 IDC	International Datacasting Corporation
-IDE	Lenovo Beijing Co. Ltd.
+IDE	IDE Associates
 IDK	IDK Corporation
 IDN	Idneo Technologies
 IDO	IDEO Product Development
@@ -1023,13 +1036,11 @@ IFZ	Infinite Z
 IGC	Intergate Pty Ltd
 IGM	IGM Communi
 IHE	InHand Electronics
-IHS	IHSE GmbH
 IIC	ISIC Innoscan Industrial Computers A/S
 III	Intelligent Instrumentation
 IIN	IINFRA Co., Ltd
 IIT	Informatik Information Technologies
 IKE	Ikegami Tsushinki Co. Ltd.
-IKN	IKON
 IKS	Ikos Systems Inc
 ILC	Image Logic Corporation
 ILS	Innotech Corporation
@@ -1044,8 +1055,8 @@ IMI	International Microsystems Inc
 IMM	Immersion Corporation
 IMN	Impossible Production
 IMP	Impinj
-IMS	Integrated Micro Solution Inc.
 IMT	Inmax Technology Corporation
+IMX	arpara Technology Co., Ltd.
 INA	Inventec Corporation
 INC	Home Row Inc
 IND	ILC
@@ -1059,21 +1070,21 @@ INM	InnoMedia Inc
 INN	Innovent Systems, Inc.
 INO	Innolab Pte Ltd
 INP	Interphase Corporation
-INS	Insyde Software
-INT	Intel Corporation
-INV	Invensense, Inc
+INS	Ines GmbH
+INT	Interphase Corporation
+INU Inovatec S.p.A.
+INV	Inviso, Inc.
 INX	Communications Supply Corporation (A division of WESCO)
 INZ	Best Buy
 IOA	CRE Technology Corporation
+IOC	Guangxi Century Innovation Display Electronics Co., Ltd
 IOD	I-O Data Device Inc
 IOM	Iomega
 ION	Inside Out Networks
 IOS	i-O Display System
 IOT	I/OTech Inc
-IP3	IP3 Technology Ltd.
 IPC	IPC Corporation
 IPD	Industrial Products Design, Inc.
-IPH	Inphi Corporation
 IPI	Intelligent Platform Management Interface (IPMI) forum (Intel, HP, NEC, Dell)
 IPM	IPM Industria Politecnica Meridionale SpA
 IPN	Performance Technologies
@@ -1114,6 +1125,7 @@ ITX	integrated Technology Express Inc
 IUC	ICSL
 IVI	Intervoice Inc
 IVM	Iiyama North America
+IVO	InfoVision Optoelectronics (Kunshan) Co.,Ltd China
 IVR	Inlife-Handnet Co., Ltd.
 IVS	Intevac Photonics Inc.
 IWR	Icuiti Corporation
@@ -1135,6 +1147,7 @@ JFX	Jones Futurex Inc
 JGD	University College
 JIC	Jaeik Information & Communication Co., Ltd.
 JKC	JVC KENWOOD Corporation
+JLK	UNIONMAN TECHNOLOGY CO., LTD
 JMT	Micro Technical Company Ltd
 JPC	JPC Technology Limited
 JPW	Wallis Hamilton Industries
@@ -1171,8 +1184,10 @@ KFE	Komatsu Forest
 KFX	Kofax Image Products
 KGI	Klipsch Group, Inc
 KGL	KEISOKU GIKEN Co.,Ltd.
+KGN	KOGAN AUSTRALIA PTY LTD
 KIO	Kionix, Inc.
 KIS	KiSS Technology A/S
+KLT	Colorlight
 KMC	Mitsumi Company Ltd
 KME	KIMIN Electronics Co., Ltd.
 KML	Kensington Microware Ltd
@@ -1184,6 +1199,7 @@ KOD	Eastman Kodak Company
 KOE	KOLTER ELECTRONIC
 KOL	Kollmorgen Motion Technologies Group
 KOM	Kontron GmbH
+KOP	Kopin Corporation
 KOU	KOUZIRO Co.,Ltd.
 KOW	KOWA Company,LTD.
 KPC	King Phoenix Company
@@ -1202,6 +1218,7 @@ KTG	Kayser-Threde GmbH
 KTI	Konica Technical Inc
 KTK	Key Tronic Corporation
 KTN	Katron Tech Inc
+KTS	Kyokko Communication System Co., Ltd.
 KUR	Kurta Corporation
 KVA	Kvaser AB
 KVX	KeyView
@@ -1217,7 +1234,6 @@ LAC	LaCie
 LAF	Microline
 LAG	Laguna Systems
 LAN	Sodeman Lancom Inc
-LAP	BenQ
 LAS	LASAT Comm. A/S
 LAV	Lava Computer MFG Inc
 LBO	Lubosoft
@@ -1227,6 +1243,7 @@ LCE	La Commande Electronique
 LCI	Lite-On Communication Inc
 LCM	Latitude Comm.
 LCN	LEXICON
+LCP	Silent Power Electronics GmbH
 LCS	Longshine Electronics Company
 LCT	Labcal Technologies
 LDN	Laserdyne Technologies
@@ -1243,24 +1260,27 @@ LGI	Logitech Inc
 LGS	LG Semicom Company Ltd
 LGX	Lasergraphics, Inc.
 LHA	Lars Haagh ApS
+LHC	Beihai Century Joint Innovation Technology Co.,Ltd
 LHE	Lung Hwa Electronics Company Ltd
 LHT	Lighthouse Technologies Limited
 LIN	Lenovo Beijing Co. Ltd.
 LIP	Linked IP GmbH
+LIS	Life is Style Inc.
 LIT	Lithics Silicon Technology
 LJX	Datalogic Corporation
 LKM	Likom Technology Sdn. Bhd.
 LLL	L-3 Communications
+LLT	LUMINO Licht Elektronik GmbH
 LMG	Lucent Technologies
 LMI	Lexmark Int'l Inc
 LMP	Leda Media Products
+LMS	Lumens Digital Optics Inc.
 LMT	Laser Master
+LNC	Lincoln Technology Solutions
 LND	Land Computer Company Ltd
-LNE	Linksys
 LNK	Link Tech Inc
-LNR	Linaro, Ltd.
+LNR	Linear Systems Ltd.
 LNT	LANETCO International
-LNU	The Linux Foundation
 LNV	Lenovo
 LNX	The Linux Foundation
 LOC	Locamation B.V.
@@ -1269,7 +1289,6 @@ LOG	Logicode Technology Inc
 LOL	Litelogic Operations Ltd
 LPE	El-PUSK Co., Ltd.
 LPI	Design Technology
-LPL	LG Philips
 LSC	LifeSize Communications
 LSD	Intersil Corporation
 LSI	Loughborough Sound Images
@@ -1303,7 +1322,7 @@ MAI	Mutoh America Inc
 MAL	Meridian Audio Ltd
 MAN	LGIC
 MAS	Mass Inc.
-MAT	Matsushita Electric Ind. Company Ltd
+MAT	Panasonic Connect Co.,Ltd.
 MAX	Rogen Tech Distribution Inc
 MAY	Maynard Electronics
 MAZ	MAZeT GmbH
@@ -1316,7 +1335,6 @@ MCC	Micro Industries
 MCD	McDATA Corporation
 MCE	Metz-Werke GmbH & Co KG
 MCG	Motorola Computer Group
-MCH	Microchip Technology Inc
 MCI	Micronics Computers
 MCJ	Medicaroid Corporation
 MCL	Motorola Communications Israel
@@ -1329,7 +1347,6 @@ MCR	Marina Communicaitons
 MCS	Micro Computer Systems
 MCT	Microtec
 MCX	Millson Custom Solutions Inc.
-MCY	Microdyne
 MDA	Media4 Inc
 MDC	Midori Electronics
 MDD	MODIS
@@ -1366,13 +1383,14 @@ MGC	Mentor Graphics Corporation
 MGE	Schneider Electric S.A.
 MGL	M-G Technology Ltd
 MGT	Megatech R & D Company
+MHQ	Moxa Inc.
 MIC	Micom Communications Inc
 MID	miro Displays
 MII	Mitec Inc
 MIL	Marconi Instruments Ltd
 MIM	Mimio – A Newell Rubbermaid Company
 MIN	Minicom Digital Signage
-MIP	MIPI Alliance
+MIP	micronpc.com
 MIR	Miro Computer Prod.
 MIS	Modular Industrial Solutions Inc
 MIT	MCM Industrial Technology GmbH
@@ -1383,6 +1401,7 @@ MKC	Media Tek Inc.
 MKS	MK Seiko Co., Ltd.
 MKT	MICROTEK Inc.
 MKV	Trtheim Technology
+MLC	MILCOTS
 MLD	Deep Video Imaging Ltd
 MLG	Micrologica AG
 MLI	McIntosh Laboratory Inc.
@@ -1400,14 +1419,15 @@ MMI	Multimax
 MMM	Electronic Measurements
 MMN	MiniMan Inc
 MMS	MMS Electronics
+MMT	MIMO Monitors
 MNC	Mini Micro Methods Ltd
 MNI	Marseille, Inc.
 MNL	Monorail Inc
 MNP	Microcom
+MNS	Maxnerva Technology Services Limited
 MOC	Matrix Orbital Corporation
 MOD	Modular Technology
 MOM	Momentum Data Systems
-MON	Daewoo
 MOS	Moses Corporation
 MOT	Motorola UDS
 MPC	M-Pact Inc
@@ -1416,22 +1436,23 @@ MPJ	Microlab
 MPL	Maple Research Inst. Company Ltd
 MPN	Mainpine Limited
 MPS	mps Software GmbH
+MPV	Megapixel Visual Realty
 MPX	Micropix Technologies, Ltd.
 MQP	MultiQ Products AB
 MRA	Miranda Technologies Inc
 MRC	Marconi Simulation & Ty-Coch Way Training
 MRD	MicroDisplay Corporation
+MRG	Nreal
 MRK	Maruko & Company Ltd
 MRL	Miratel
 MRO	Medikro Oy
 MRT	Merging Technologies
-MRV	Marvell Technology Group Ltd.
-MSA	Microsoft Corporation
+MSA	Micro Systemation AB
 MSC	Mouse Systems Corporation
 MSD	Datenerfassungs- und Informationssysteme
-MSF	Microsoft Corporation
+MSF	M-Systems Flash Disk Pioneers
 MSG	MSI GmbH
-MSH	Microsoft Corporation
+MSH	Microsoft
 MSI	Microstep
 MSK	Megasoft Inc
 MSL	MicroSlate Inc.
@@ -1457,6 +1478,7 @@ MTM	Motium
 MTN	Mtron Storage Technology Co., Ltd.
 MTR	Mitron computer Inc
 MTS	Multi-Tech Systems
+MTT	Moore Threads Virtual Display
 MTU	Mark of the Unicorn Inc
 MTX	Matrox
 MUD	Multi-Dimension Institute
@@ -1472,8 +1494,9 @@ MWI	Multiwave Innovation Pte Ltd
 MWR	mware
 MWY	Microway Inc
 MXD	MaxData Computer GmbH & Co.KG
-MXI	Maxim Integrated
+MXI	Macronix Inc
 MXL	Hitachi Maxell, Ltd.
+MXM	C&T Solution Inc.
 MXP	Maxpeed Corporation
 MXT	Maxtech Corporation
 MXV	MaxVision Corporation
@@ -1482,9 +1505,9 @@ MYR	Myriad Solutions Ltd
 MYX	Micronyx Inc
 NAC	Ncast Corporation
 NAD	NAD Electronics
+NAF	NAFASAE INDIA Pvt. Ltd
 NAK	Nakano Engineering Co.,Ltd.
 NAL	Network Alchemy
-NAN	Nanao
 NAT	NaturalPoint Inc.
 NAV	Navigation Corporation
 NAX	Naxos Tecnologia
@@ -1500,6 +1523,7 @@ NCP	Najing CEC Panda FPD Technology CO. ltd
 NCR	NCR Electronics
 NCS	Northgate Computer Systems
 NCT	NEC CustomTechnica, Ltd.
+NCV	NewCoSemi (Beijing) Technology CO.,Ltd.
 NDC	National DataComm Corporaiton
 NDF	NDF Special Light Products B.V.
 NDI	National Display Systems
@@ -1516,6 +1540,7 @@ NFC	BTC Korea Co., Ltd
 NFS	Number Five Software
 NGC	Network General
 NGS	A D S Exports
+NHC	New H3C Technology Co., Ltd.
 NHT	Vinci Labs
 NIC	National Instruments Corporation
 NIS	Nissei Electric Company
@@ -1562,19 +1587,24 @@ NVC	NetVision Corporation
 NVD	Nvidia
 NVI	NuVision US, Inc.
 NVL	Novell Inc
-NVT	Nuvoton Technology Corporation
+NVO	Netvio Ltd.
+NVR	NOLO CO., LTD.
+NVT	Navatek Engineering Corporation
 NWC	NW Computer Engineering
+NWL	Newline Interactive Inc.
 NWP	NovaWeb Technologies Inc
 NWS	Newisys, Inc.
 NXC	NextCom K.K.
-NXG	Nexstgo Company Limited
+NXE	Norxe AS
+NXG	Nexgen
 NXP	NXP Semiconductors bv.
 NXQ	Nexiq Technologies, Inc.
+NXR	Nextorage Corporation
 NXS	Technology Nexus Secure Open Systems AB
+NXT	NZXT (PNP same EDID)_
 NYC	Nakayo Relecommunications, Inc.
 OAK	Oak Tech Inc
 OAS	Oasys Technology Company
-OBD	REALTEK Semiconductor Corp.
 OBS	Optibase Technologies
 OCD	Macraigor Systems Inc
 OCN	Olfan
@@ -1583,6 +1613,7 @@ ODM	ODME Inc.
 ODR	Odrac
 OEC	ORION ELECTRIC CO.,LTD
 OEI	Optum Engineering Inc.
+OFI	Jiangxi Jinghao Optical Co., Ltd.
 OHW	M-Labs Limited
 OIC	Option Industrial Computers
 OIM	Option International
@@ -1595,8 +1626,8 @@ OLT	Olitec S.A.
 OLV	Olitec S.A.
 OLY	OLYMPUS CORPORATION
 OMC	OBJIX Multimedia Corporation
+OMG	RODE
 OMN	Omnitel
-OMP	OmniPreSense
 OMR	Omron Corporation
 ONE	Oneac Corporation
 ONK	ONKYO Corporation
@@ -1616,24 +1647,26 @@ ORI	OSR Open Systems Resources, Inc.
 ORN	ORION ELECTRIC CO., LTD.
 OSA	OSAKA Micro Computer, Inc.
 OSD	Optical Systems Design Pty Ltd
+OSE	Osee
 OSI	Open Stack, Inc.
 OSP	OPTI-UPS Corporation
 OSR	Oksori Company Ltd
 OTB	outsidetheboxstuff.com
 OTI	Orchid Technology
 OTK	OmniTek
-OTM	Optoma Corporation
+OTM	Optoma Corporation          
 OTT	OPTO22, Inc.
 OUK	OUK Company Ltd
 OVR	Oculus VR, Inc.
-OVT	OmniVision Technologies, Inc.
 OWL	Mediacom Technologies Pte Ltd
 OXU	Oxus Research S.A.
 OYO	Shadow Systems
 OZC	OZ Corporation
+OZD	OZO Co.Ltd
 OZO	Tribe Computer Works Inc
 PAC	Pacific Avionics Corporation
 PAD	Promotion and Display Technology Ltd.
+PAE	PreSonus Audio Electronics
 PAK	Many CNC System Co., Ltd.
 PAM	Peter Antesberger Messtechnik
 PAN	The Panda Project
@@ -1656,7 +1689,6 @@ PCS	TOSHIBA PERSONAL COMPUTER SYSTEM CORPRATION
 PCT	PC-Tel Inc
 PCW	Pacific CommWare Inc
 PCX	PC Xperten
-PDC	Polaroid
 PDM	Psion Dacom Plc.
 PDN	AT&T Paradyne
 PDR	Pure Data Inc
@@ -1686,6 +1718,8 @@ PIC	Picturall Ltd.
 PIE	Pacific Image Electronics Company Ltd
 PIM	Prism, LLC
 PIO	Pioneer Electronic Corporation
+PIR	Pico Technology Inc.
+PIS	TECNART CO.,LTD.
 PIX	Pixie Tech Inc
 PJA	Projecta
 PJD	Projectiondesign AS
@@ -1706,6 +1740,7 @@ PMT	Promate Electronic Co., Ltd.
 PMX	Photomatrix
 PNG	Microsoft
 PNL	Panelview, Inc.
+PNP	Microsoft
 PNR	Planar Systems, Inc.
 PNS	PanaScope
 PNT	HOYA Corporation PENTAX Lifecare Division
@@ -1729,6 +1764,7 @@ PRD	Praim S.R.L.
 PRF	Schneider Electric Japan Holdings, Ltd.
 PRG	The Phoenix Research Group Inc
 PRI	Priva Hortimation BV
+PRK	Portkeys
 PRM	Prometheus
 PRO	Proteon
 PRP	UEFI Forum
@@ -1751,6 +1787,7 @@ PTH	Pathlight Technology Inc
 PTI	Promise Technology Inc
 PTL	Pantel Inc
 PTS	Plain Tree Systems Inc
+PTX	Printronix LLC
 PUL	Pulse-Eight Ltd
 PVG	Proview Global Co., Ltd
 PVI	Prime view international Co., Ltd
@@ -1763,18 +1800,17 @@ PXE	PIXELA CORPORATION
 PXL	The Moving Pixel Company
 PXM	Proxim Inc
 PXN	PixelNext Inc
+PXO	Pixio USA
 QCC	QuakeCom Company Ltd
 QCH	Metronics Inc
 QCI	Quanta Computer Inc
 QCK	Quick Corporation
 QCL	Quadrant Components Inc
-QCO	Qualcomm Inc
 QCP	Qualcomm Inc
 QDI	Quantum Data Incorporated
 QDL	QD Laser, Inc.
 QDM	Quadram
 QDS	Quanta Display Inc.
-QEM	Red Hat, Inc.
 QFF	Padix Co., Inc.
 QFI	Quickflex, Inc
 QLC	Q-Logic
@@ -1796,13 +1832,14 @@ RAN	Rancho Tech Inc
 RAR	Raritan, Inc.
 RAS	RAScom Inc
 RAT	Rent-A-Tech
-RAY	Raydium Semiconductor Corporation
+RAY	Raylar Design, Inc.
 RCE	Parc d'Activite des Bellevues
 RCH	Reach Technology Inc
 RCI	RC International
 RCN	Radio Consult SRL
 RCO	Rockwell Collins
 RDI	Rainbow Displays, Inc.
+RDL	Riedel Communications Canada Inc.
 RDM	Tremon Enterprises Company Ltd
 RDN	RADIODATA GmbH
 RDS	Radius Inc
@@ -1832,7 +1869,7 @@ RIT	Ritech Inc
 RIV	Rivulet Communications
 RJA	Roland Corporation
 RJS	Advanced Engineering
-RKC	Fuzhou Rockchip Electronics Co., Ltd.
+RKC	Reakin Technolohy Corporation
 RLD	MEPCO
 RLN	RadioLAN Inc
 RMC	Raritan Computer, Inc
@@ -1840,6 +1877,7 @@ RMP	Research Machines
 RMS	Shenzhen Ramos Digital Technology Co., Ltd
 RMT	Roper Mobile
 RNB	Rainbow Technologies
+RNL	Reonel Oy
 ROB	Robust Electronics GmbH
 ROH	Rohm Co., Ltd.
 ROK	Rockwell International
@@ -1848,6 +1886,7 @@ ROS	Rohde & Schwarz
 RPI	RoomPro Technologies
 RPT	R.P.T.Intergroups
 RRI	Radicom Research Inc
+RRO	AVARRO
 RSC	PhotoTelesis
 RSH	ADC-Centre
 RSI	Rampage Systems Inc
@@ -1884,10 +1923,12 @@ SBD	Softbed - Consulting & Development Ltd
 SBI	SMART Technologies Inc.
 SBS	SBS-or Industrial Computers GmbH
 SBT	Senseboard Technologies AB
+SCA	Schneider Consumer Group
 SCB	SeeCubic B.V.
 SCC	SORD Computer Corporation
 SCD	Sanyo Electric Company Ltd
 SCE	Sun Corporation
+SCG	Seco S.p.A.
 SCH	Schlumberger Cards
 SCI	System Craft
 SCL	Sigmacom Co., Ltd.
@@ -1900,6 +1941,7 @@ SCS	Nanomach Anstalt
 SCT	Smart Card Technology
 SCX	Socionext Inc.
 SDA	SAT (Societe Anonyme)
+SDC	Samsung Display Corp.
 SDD	Intrada-SDD Ltd
 SDE	Sherwood Digital Electronics Corporation
 SDF	SODIFF E&T CO., Ltd.
@@ -1923,6 +1965,7 @@ SEP	SEP Eletronica Ltda.
 SER	Sony Ericsson Mobile Communications Inc.
 SES	Session Control LLC
 SET	SendTek Corporation
+SFL	Shiftall Inc.
 SFM	TORNADO Company
 SFT	Mikroforum Ring 3
 SGC	Spectragraphics Corporation
@@ -1931,16 +1974,18 @@ SGE	Kansai Electric Company Ltd
 SGI	Scan Group Ltd
 SGL	Super Gate Technology Company Ltd
 SGM	SAGEM
+SGN	Shenzhen Soogeen Electronics Co., LTD.
 SGO	Logos Design A/S
 SGT	Stargate Technology
 SGW	Shanghai Guowei Science and Technology Co., Ltd.
 SGX	Silicon Graphics Inc
 SGZ	Systec Computer GmbH
 SHC	ShibaSoku Co., Ltd.
+SHD	SmallHD
 SHG	Soft & Hardware development Goldammer GmbH
 SHI	Jiangsu Shinco Electronic Group Co., Ltd
 SHP	Sharp Corporation
-SHR	Sharp Corporation
+SHR	Digital Discovery
 SHT	Shin Ho Tech
 SIA	SIEMENS AG
 SIB	Sanyo Electric Company Ltd
@@ -1959,8 +2004,11 @@ SIU	Seiko Instruments USA Inc
 SIX	Zuniq Data Corporation
 SJE	Sejin Electron Inc
 SKD	Schneider & Koch
+SKG	Shenzhen KTC Technology Group
+SKI	LLC SKTB “SKIT”
 SKM	Guangzhou Teclast Information Technology Limited
 SKT	Samsung Electro-Mechanics Company Ltd
+SKW	Skyworth
 SKY	SKYDATA S.P.A.
 SLA	Systeme Lauer GmbH&Co KG
 SLB	Shlumberger Ltd
@@ -1982,6 +2030,7 @@ SMI	SpaceLabs Medical Inc
 SMK	SMK CORPORATION
 SML	Sumitomo Metal Industries, Ltd.
 SMM	Shark Multimedia Inc
+SMN	Somnium Space Ltd.
 SMO	STMicroelectronics
 SMP	Simple Computing
 SMR	B.& V. s.r.l.
@@ -1993,7 +2042,7 @@ SNK	S&K Electronics
 SNN	SUNNY ELEKTRONIK
 SNO	SINOSUN TECHNOLOGY CO., LTD
 SNP	Siemens Nixdorf Info Systems
-SNS	Sensel, Inc.
+SNS	Cirtech (UK) Ltd
 SNT	SuperNet Inc
 SNV	SONOVE GmbH
 SNW	Snell & Wilcox
@@ -2002,7 +2051,7 @@ SNY	Sony
 SOC	Santec Corporation
 SOI	Silicon Optix Corporation
 SOL	Solitron Technologies Inc
-SON	Sony Corporation
+SON	Sony
 SOR	Sorcus Computer GmbH
 SOT	Sotec Company Ltd
 SOY	SOYO Group, Inc
@@ -2013,6 +2062,7 @@ SPI	SPACE-I Co., Ltd.
 SPK	SpeakerCraft
 SPL	Smart Silicon Systems Pty Ltd
 SPN	Sapience Corporation
+SPO	SAMPO CORPORATION
 SPR	pmns GmbH
 SPS	Synopsys Inc
 SPT	Sceptre Tech Inc
@@ -2028,13 +2078,13 @@ SRT	SeeReal Technologies GmbH
 SSC	Sierra Semiconductor Inc
 SSD	FlightSafety International
 SSE	Samsung Electronic Co.
+SSG	Steelseries ApS
 SSI	S-S Technology Inc
 SSJ	Sankyo Seiki Mfg.co., Ltd
 SSL	Shenzhen South-Top Computer Co., Ltd.
 SSP	Spectrum Signal Proecessing Inc
 SSS	S3 Inc
 SST	SystemSoft Corporation
-ST8	Shenzhen South-Top Computer Co., Ltd.
 STA	ST Electronics Systems Assembly Pte Ltd
 STB	STB Systems Inc
 STC	STAC Electronics
@@ -2055,6 +2105,7 @@ STR	Starlight Networks Inc
 STS	SITECSYSTEM CO., LTD.
 STT	Star Paging Telecom Tech (Shenzhen) Co. Ltd.
 STU	Sentelic Corporation
+STV	Beijing Guochengwantong Information Technology Co., Ltd.
 STW	Starwin Inc.
 STX	ST-Ericsson
 STY	SDS Technologies
@@ -2066,13 +2117,11 @@ SUR	Surenam Computer Corporation
 SVA	SGEG
 SVC	Intellix Corp.
 SVD	SVD Computer
-SVE	SVEC
 SVI	Sun Microsystems
 SVR	Sensics, Inc.
 SVS	SVSI
 SVT	SEVIT Co., Ltd.
 SWC	Software Café
-SWE	Sierra Wireless
 SWI	Sierra Wireless Inc.
 SWL	Sharedware Ltd
 SWO	Guangzhou Shirui Electronics Co., Ltd.
@@ -2096,7 +2145,6 @@ SYT	Seyeon Tech Company Ltd
 SYV	SYVAX Inc
 SYX	Prime Systems, Inc.
 SZM	Shenzhen MTC Co., Ltd
-SZV	OvisLink
 TAA	Tandberg
 TAB	Todos Data System AB
 TAG	Teles AG
@@ -2109,7 +2157,6 @@ TAX	Taxan (Europe) Ltd
 TBB	Triple S Engineering Inc
 TBC	Turbo Communication, Inc
 TBS	Turtle Beach System
-TCA	Teracue AG
 TCC	Tandon Corporation
 TCD	Taicom Data Systems Co., Ltd.
 TCE	Century Corporation
@@ -2128,7 +2175,6 @@ TCX	FREEMARS Heavy Industries
 TDC	Teradici
 TDD	Tandberg Data Display AS
 TDG	Six15 Technologies
-TDK	TDK USA Corporation
 TDM	Tandem Computer Europe Inc
 TDP	3D Perception
 TDS	Tri-Data Systems Inc
@@ -2143,13 +2189,13 @@ TEN	Tencent
 TER	TerraTec Electronic GmbH
 TET	TETRADYNE CO., LTD.
 TEV	Televés, S.A.
-TEX	Texas Instruments
 TEZ	Tech Source Inc.
 TGC	Toshiba Global Commerce Solutions, Inc.
 TGI	TriGem Computer Inc
 TGM	TriGem Computer,Inc.
 TGS	Torus Systems Ltd
 TGV	Grass Valley Germany GmbH
+TGW	TECHNOGYM S.p.A.
 THN	Thundercom Holdings Sdn. Bhd.
 TIC	Trigem KinfoComm
 TIL	Technical Illusions Inc.
@@ -2165,6 +2211,7 @@ TLA	Ferrari Electronic GmbH
 TLD	Telindus
 TLE	Zhejiang Tianle Digital Electric Co., Ltd.
 TLF	Teleforce.,co,ltd
+TLG	TVLogic
 TLI	TOSHIBA TELI CORPORATION
 TLK	Telelink AG
 TLL	Thinklogical
@@ -2173,13 +2220,17 @@ TLS	Teleste Educational OY
 TLT	Dai Telecom S.p.A.
 TLV	S3 Inc
 TLX	Telxon Corporation
+TLY	Truly Semiconductors Ltd.
+TMA	Tianma Microelectronics Ltd.
 TMC	Techmedia Computer Systems Corporation
 TME	AT&T Microelectronics
 TMI	Texas Microsystem
 TMM	Time Management, Inc.
+TMO	Terumo Corporation
 TMR	Taicom International Inc
 TMS	Trident Microsystems Ltd
 TMT	T-Metrics Inc.
+TMV	TeamViewer Germany GmbH
 TMX	Thermotrex Corporation
 TNC	TNC Industrial Company Ltd
 TNM	TECNIMAGEN SA
@@ -2190,7 +2241,7 @@ TOL	TCL Corporation
 TOM	Ceton Corporation
 TON	TONNA
 TOP	Orion Communications Co., Ltd.
-TOS	Toshiba Corporation
+TOS	Dynabook Inc.
 TOU	Touchstone Technology
 TPC	Touch Panel Systems Corporation
 TPD	Times (Shanghai) Computer Co., Ltd.
@@ -2239,6 +2290,7 @@ TTI	Trenton Terminals Inc
 TTK	Totoku Electric Company Ltd
 TTL	2-Tel B.V
 TTP	Toshiba Corporation
+TTR	Hubei Century Joint Innovation Technology Co.Ltd
 TTS	TechnoTrend Systemtechnik GmbH
 TTX	Taitex Corporation
 TTY	TRIDELITY Display Solutions GmbH
@@ -2264,7 +2316,7 @@ TXT	Textron Defense System
 TYN	Tyan Computer Corporation
 UAS	Ultima Associates Pte Ltd
 UBI	Ungermann-Bass Inc
-UBL	u-blox AG
+UBL	Ubinetics Ltd.
 UBU	Canonical Ltd.
 UDN	Uniden Corporation
 UEC	Ultima Electronics Corporation
@@ -2284,9 +2336,6 @@ UMT	UltiMachine
 UNA	Unisys DSD
 UNB	Unisys Corporation
 UNC	Unisys Corporation
-UND	Unisys Corporation
-UNE	Unisys Corporation
-UNF	Unisys Corporation
 UNI	Uniform Industry Corp.
 UNM	Unisys Corporation
 UNO	Unisys Corporation
@@ -2298,11 +2347,11 @@ UPP	UPPI
 UPS	Systems Enhancement
 URD	Video Computer S.p.A.
 USA	Utimaco Safeware AG
-USC	UltraStor
 USD	U.S. Digital Corporation
 USE	U. S. Electronics Inc.
 USI	Universal Scientific Industrial Co., Ltd.
 USR	U.S. Robotics Inc
+UTC	Unicompute Technology Co., Ltd.
 UTD	Up to Date Tech
 UWC	Uniwill Computer Corp.
 VAD	Vaddio, LLC
@@ -2310,9 +2359,11 @@ VAI	VAIO Corporation
 VAL	Valence Computing Corporation
 VAR	Varian Australia Pty Ltd
 VAT	VADATECH INC
+VAV	aviica
 VBR	VBrick Systems Inc.
 VBT	Valley Board Ltda
 VCC	Virtual Computer Corporation
+VCE	VARCem
 VCI	VistaCom Inc
 VCJ	Victor Company of Japan, Limited
 VCM	Vector Magnetics, LLC
@@ -2327,7 +2378,6 @@ VEC	Vector Informatik GmbH
 VEK	Vektrex
 VES	Vestel Elektronik Sanayi ve Ticaret A. S.
 VFI	VeriFone Inc
-VFS	Validity Sensors, Inc
 VHI	Macrocad Development Inc.
 VIA	VIA Tech Inc
 VIB	Tatung UK Ltd
@@ -2336,6 +2386,7 @@ VID	Ingram Macrotron Germany
 VIK	Viking Connectors
 VIM	Via Mons Ltd.
 VIN	Vine Micros Ltd
+VIO	Zake IP Holdings LLC (3B tech)
 VIR	Visual Interface, Inc
 VIS	Visioneer
 VIT	Visitech AS
@@ -2343,12 +2394,14 @@ VIZ	VIZIO, Inc
 VLB	ValleyBoard Ltda.
 VLC	VersaLogic Corporation
 VLK	Vislink International Ltd
+VLM	LENOVO BEIJING CO. LTD.
 VLT	VideoLan Technologies
 VLV	Valve Corporation
 VMI	Vermont Microsystems
 VML	Vine Micros Limited
 VMW	VMware Inc.,
 VNC	Vinca Corporation
+VNX	Venetex Corporation
 VOB	MaxData Computer AG
 VPI	Video Products Inc
 VPR	Best Buy
@@ -2361,7 +2414,6 @@ VRS	VRstudios, Inc.
 VRT	Varjo Technologies
 VSC	ViewSonic Corporation
 VSD	3M
-VSH	Vishay Intertechnology, Inc.
 VSI	VideoServer
 VSN	Ingram Macrotron
 VSP	Vision Systems GmbH
@@ -2378,6 +2430,7 @@ VTS	VTech Computers Ltd
 VTV	VATIV Technologies
 VTX	Vestax Corporation
 VUT	Vutrix (UK) Ltd
+VVI	VITEC
 VWB	Vweb Corp.
 WAC	Wacom Tech
 WAL	Wave Access
@@ -2385,13 +2438,12 @@ WAV	Wavephore
 WBN	MicroSoftWare
 WBS	WB Systemtechnik GmbH
 WCI	Wisecom Inc
-WCO	Wacom
 WCS	Woodwind Communications Systems Inc
 WDC	Western Digital
 WDE	Westinghouse Digital Electronics
 WEB	WebGear Inc
 WEC	Winbond Electronics Corporation
-WEL	W-DEV
+WEL W-DEV
 WEY	WEY Design AG
 WHI	Whistle Communications
 WII	Innoware Inc
@@ -2400,6 +2452,8 @@ WIN	Wintop Technology Inc
 WIP	Wipro Infotech
 WKH	Uni-Take Int'l Inc.
 WLD	Wildfire Communications Inc
+WLF	WOLF Advanced Technology
+WMI	Weidmuller Interface GmbH & Co. KG
 WML	Wolfson Microelectronics Ltd
 WMO	Westermo Teleindustri AB
 WMT	Winmate Communication Inc
@@ -2410,7 +2464,6 @@ WPA	Matsushita Communication Industrial Co., Ltd.
 WPI	Wearnes Peripherals International (Pte) Ltd
 WRC	WiNRADiO Communications
 WSC	CIS Technology Inc
-WSD	Winsider Seminars & Solutions Inc.
 WSP	Wireless And Smart Products Inc.
 WST	Wistron Corporation
 WTC	ACC Microelectronics
@@ -2423,7 +2476,7 @@ WWP	Wipotec Wiege- und Positioniersysteme GmbH
 WWV	World Wide Video, Inc.
 WXT	Woxter Technology Co. Ltd
 WYR	WyreStorm Technologies LLC
-WYS	Wyse Technology
+WYS	Myse Technology
 WYT	Wooyoung Image & Information Co.,Ltd.
 XAC	XAC Automation Corp
 XAD	Alpha Data
@@ -2436,7 +2489,6 @@ XIO	Xiotech Corporation
 XIR	Xirocm Inc
 XIT	Xitel Pty ltd
 XLX	Xilinx, Inc.
-XMC	Xiaomi Inc.
 XMM	C3PO S.L.
 XNT	XN Technologies, Inc.
 XQU	SHANGHAI SVA-DAV ELECTRONICS CO., LTD
@@ -2461,7 +2513,6 @@ ZAX	Zefiro Acoustics
 ZAZ	ZeeVee, Inc.
 ZBR	Zebra Technologies International, LLC
 ZBX	Zebax Technologies
-ZCM	Zenith
 ZCT	ZeitControl cardsystems GmbH
 ZDS	Zenith Data Systems
 ZEN	ZENIC Inc.
@@ -2486,4 +2537,3 @@ ZYP	Zypcom Inc
 ZYT	Zytex Computers
 ZYX	Zyxel
 ZZZ	Boca Research Inc
-inu	Inovatec S.p.A.

--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -13370,7 +13370,7 @@ usage: spotread [-options] [logfile]
                 else:
                     value = None
                 if value is not None:
-                    ti3[0].add_keyword(keyword, safe_str(value, "UTF-7"))
+                    ti3[0].add_keyword(keyword, safe_str(value, "utf-8"))
                 elif keyword in ti3[0]:
                     ti3[0].remove_keyword(keyword)
             # 3D LUT content color space (currently only used for HDR)
@@ -13384,7 +13384,7 @@ usage: spotread [-options] [logfile]
                         value = getcfg(
                             "3dlut.content.colorspace.{}.{}".format(color, coord)
                         )
-                        ti3[0].add_keyword(keyword, safe_str(value, "UTF-7"))
+                        ti3[0].add_keyword(keyword, safe_str(value, "utf-8"))
                     elif keyword in ti3[0]:
                         ti3[0].remove_keyword(keyword)
             ti3[0].fix_zero_measurements(logfile=self.get_logfiles(False))

--- a/DisplayCAL/wxCCXXPlot.py
+++ b/DisplayCAL/wxCCXXPlot.py
@@ -346,13 +346,13 @@ class CCXXPlot(wx.Frame):
             x_label = [lang.getstr("matrix")]
             x_label.extend(["%9.6f %9.6f %9.6f" % tuple(row) for row in mtx])
             if ref:
-                ref_observer = cgats.queryv1("REFERENCE_OBSERVER").decode("utf-8")
-                if ref_observer:
-                    ref += ", " + observers_ab.get(ref_observer, ref_observer)
+                ref_observer = cgats.queryv1("REFERENCE_OBSERVER")
+                if ref_observer is not None: # If the .ccmx does not contain this value, the graph will still draw
+                    ref += ", " + observers_ab.get(ref_observer.decode("utf-8"), ref_observer.decode("utf-8"))
                 x_label.append("")
                 x_label.append(ref)
-            fit_method = cgats.queryv1("FIT_METHOD").decode("utf-8")
-            if fit_method == "xy":
+            fit_method = cgats.queryv1("FIT_METHOD")
+            if fit_method is not None and fit_method.decode("utf-8") == "xy": # If the .ccmx does not contain this value, the graph will still draw
                 fit_method = lang.getstr("ccmx.use_four_color_matrix_method")
             elif fit_method:
                 fit_method = lang.getstr("perceptual")

--- a/DisplayCAL/wxCCXXPlot.py
+++ b/DisplayCAL/wxCCXXPlot.py
@@ -413,6 +413,7 @@ class CCXXPlot(wx.Frame):
             self.Sizer.Add(bg, 1, flag=wx.EXPAND)
             bg.Sizer.Add(canvas, 1, flag=wx.EXPAND)
         else:
+            bg.MinSize = (int(400 * scale), int(400 * scale))
             self.Sizer.Add(bg, flag=wx.ALIGN_CENTER)
             canvas_w = int(240 * scale)
             canvas.MinSize = (int(canvas_w), int(canvas_w * (74.6 / 67.4)))

--- a/DisplayCAL/wxCCXXPlot.py
+++ b/DisplayCAL/wxCCXXPlot.py
@@ -347,12 +347,17 @@ class CCXXPlot(wx.Frame):
             x_label.extend(["%9.6f %9.6f %9.6f" % tuple(row) for row in mtx])
             if ref:
                 ref_observer = cgats.queryv1("REFERENCE_OBSERVER")
-                if ref_observer is not None: # If the .ccmx does not contain this value, the graph will still draw
-                    ref += ", " + observers_ab.get(ref_observer.decode("utf-8"), ref_observer.decode("utf-8"))
+                if ref_observer:
+                    # If the .ccmx does not contain this value,
+                    # the graph will still draw
+                    ref_observer = ref_observer.decode("utf-8")
+                    ref += ", " + observers_ab.get(ref_observer, ref_observer)
                 x_label.append("")
                 x_label.append(ref)
             fit_method = cgats.queryv1("FIT_METHOD")
-            if fit_method is not None and fit_method.decode("utf-8") == "xy": # If the .ccmx does not contain this value, the graph will still draw
+            if fit_method == b"xy":
+                # If the .ccmx does not contain this value,
+                # the graph will still draw
                 fit_method = lang.getstr("ccmx.use_four_color_matrix_method")
             elif fit_method:
                 fit_method = lang.getstr("perceptual")


### PR DESCRIPTION
Previously, I was unable to create colorimeter corrections through the DisplayCAL GUI, so these changes fix the errors and bugs I encountered in the process. 

1. The i1 Pro 3 is now recognized as a spectrometer and shows as a reference instrument in the dialog.
2. The most recent spectrometer measurement is correctly saved in the reference file dropdown instead of in the colorimeter dropdown. This means a sequential colorimeter measurement, which automatically triggers the correction creation step, will correctly use the most recent reference measurement.
3. If using a virtual display like Resolve, that display name will be included in the dialog box. Previously, this would cause an error because that variable was not assigned a value. _Note that this is a temporary fix just to solve the problem within the colorimeter correction workflow. This seems to be a byte vs. string problem elsewhere in how the name of the display is added to the ARGYLL_COLPROF_ARGS section of the reference.ti3 file, but I couldn't find the root cause and didn't want to break anything outside of this workflow._
5. After a .ccmx is created, the colorimeter correction information button now draws the graph in a reasonably sized GUI window. Previously, the window was the full width of the display and could not be resized.
6. If a .ccmx is loaded that was not created within DisplayCAL (ie. created with the ArgyllCMS ccxxmake command line tool, which is what I was doing before), it can still be graphed. Previously, an error would occur if the file did not contain some additional values that DisplayCAL adds to the file.

Please let me know if any of these changes should be implemented differently or in a more semantically correct way. This is the first I've dabbled into Python and was just trying to solve the immediate error messages I was getting in order to get the workflow usable. Figured I'd start learning by fixing what was bothering me. 