### PR TITLE
Fix error DisplayCAL is already installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,19 @@ help:
 	@echo "Available targets:"
 	@make -qp | grep -o '^[a-z0-9-]\+' | sort
 
-venv:
+environment:
 	python3 -m venv $(VIRTUALENV_DIR); \
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
 	pip install -r requirements.txt; \
 	pip install -r requirements-dev.txt;
 
-build: venv FORCE
+build: environment FORCE
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
 	python3 -m build;
 
 install:
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
-	pip install ./dist/DisplayCAL-$(VERSION)-*.whl;
+	pip install ./dist/DisplayCAL-$(VERSION)-*.whl --force-reinstall;
 
 launch:
 	source ./.venv/bin/activate; \
@@ -66,7 +66,7 @@ new-release:
 # 	twine upload dist/DisplayCAL-$(VERSION).whl
 	twine upload dist/DisplayCAL-$(VERSION).tar.gz
 
-tests: venv build install
+tests: environment build install
 	source $(VIRTUALENV_DIR)/bin/activate; \
 	pytest -v -n auto -W ignore --color=yes --cov-report term;
 

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ help:
 	@echo "Available targets:"
 	@make -qp | grep -o '^[a-z0-9-]\+' | sort
 
-environment:
+.PHONY: venv
+venv:
 	python3 -m venv $(VIRTUALENV_DIR); \
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
 	pip install -r requirements.txt; \
 	pip install -r requirements-dev.txt;
 
-build: environment FORCE
+build: venv FORCE
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
 	python3 -m build;
 
@@ -66,7 +67,7 @@ new-release:
 # 	twine upload dist/DisplayCAL-$(VERSION).whl
 	twine upload dist/DisplayCAL-$(VERSION).tar.gz
 
-tests: environment build install
+tests: venv build install
 	source $(VIRTUALENV_DIR)/bin/activate; \
 	pytest -v -n auto -W ignore --color=yes --cov-report term;
 


### PR DESCRIPTION
Fix ERROR: venv is up-to-date

If the user has an existing `venv` folder in the main project directory, `make build` will fail since `make venv` will exit with the message that the build target venv is up-to-date. This situation occurs when the popular PyCharm IDE is used with the project that creates a venv folder for its environment. Renaming the build target avoids this collision.

Fix ERROR: DisplayCAL is already installed

After `make build` pip will already list DisplayCAL as an installed packaged which can be verified with `pip list | grep DisplayCAL` and therefor not install DisplayCAL despite the fact that `.venv/bin/displaycal` doesn't exist. Adding --force-reinstall will avoid this error.