### PR TITLE
testing environment includes python 3.12

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,9 @@ jobs:
           - python-version: "3.11"
             wx-version: "4.1.1"
           - python-version: "3.12"
-            wx-version: "4.1.1"
+            wx-version:
+              - "4.1.1"
+              - "4.2.0"
 
     steps:
 
@@ -45,6 +47,8 @@ jobs:
           echo "add_dir_str=cpython-310" >> $GITHUB_ENV
         elif [ "${{ matrix.python-version }}" == "3.11" ]; then
           echo "add_dir_str=cpython-311" >> $GITHUB_ENV
+        elif [ "${{ matrix.python-version }}" == "3.12" ]; then
+          echo "add_dir_str=cpython-312" >> $GITHUB_ENV
         fi
 
     - name: Setup timezone

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set Environment Variables
       run: |
@@ -50,11 +50,6 @@ jobs:
         elif [ "${{ matrix.python-version }}" == "3.12" ]; then
           echo "add_dir_str=cpython-312" >> $GITHUB_ENV
         fi
-
-    - name: Setup timezone
-      uses: zcong1993/setup-timezone@master
-      with:
-        timezone: UTC
 
     - name: Setup xvfb
       run: |
@@ -73,7 +68,7 @@ jobs:
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,9 +28,9 @@ jobs:
           - python-version: "3.11"
             wx-version: "4.1.1"
           - python-version: "3.12"
-            wx-version:
-              - "4.1.1"
-              - "4.2.0"
+            wx-version: "4.1.1"
+          - python-version: "3.12"
+            wx-version: "4.2.0"
 
     steps:
 


### PR DESCRIPTION
Wheels for wxPython and python 3.12 can only be provided for wxPython-4.2.1. That is because in wxPython-4.2.0 there are still used some PyUnicode functions which were removed in python 3.12. For example _PyUnicode_GET_SIZE_.