### PR TITLE
Minor documentation update; tweak to Makefile to deal with python version issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SETUP_PY_FLAGS = --use-distutils
 VERSION := $(shell cat VERSION_BASE)
 VERSION_FILE=$(CURDIR)/VERSION_BASE
 VIRTUALENV_DIR:=.venv
+SYSTEM_PYTHON:=python3
 
 all: build FORCE
 
@@ -15,7 +16,7 @@ help:
 
 .PHONY: venv
 venv:
-	python3 -m venv $(VIRTUALENV_DIR); \
+	$(SYSTEM_PYTHON) -m venv $(VIRTUALENV_DIR); \
 	source ./$(VIRTUALENV_DIR)/bin/activate; \
 	pip install -r requirements.txt; \
 	pip install -r requirements-dev.txt;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a screenshots showing the tool working with Python 3.10:
 
 ![image](https://user-images.githubusercontent.com/1786804/169152229-e06ff549-55fe-4149-8742-405446e6b01f.png)
 
-Currently, DisplayCAL is working with Python 3.8 to 3.12 and wxPython 4.1.1 to 4.2.1.
+Currently, DisplayCAL is working with Python 3.8 to 3.11 and wxPython 4.1.1 to 4.2.1.
 
 Here is a list of things that is working:
 
@@ -108,11 +108,11 @@ eg
 
 ```shell
 $ python3 --version
-# Python 3.13.0
-make build # this will fail
-$ python3.12 --version
 # Python 3.12.2
-make SYSTEM_PYTHON=python3.12 build # should work
+make build # this will fail
+$ python3.11 --version
+# Python 3.11.8
+make SYSTEM_PYTHON=python3.11 build # should work
 ```
 
 If this errors out for you, you can follow the [Manual Setup](https://github.com/eoyilmaz/displaycal-py3#manually-setup)
@@ -131,7 +131,7 @@ If the `makefile` workflow doesn't work for you, you can setup the virtual envir
 manually. Ensure the python binary you're using is supported:
 
 ```shell
-python -m venv .venv # python3.12 -m venv .venv if system python is not a supported version
+python -m venv .venv # python3.11 -m venv .venv if system python is not a supported version
 source .venv/bin/activate  # Windows: .venv\Scripts\activate.bat
 pip install -r requirements.txt
 python -m build

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a screenshots showing the tool working with Python 3.10:
 
 ![image](https://user-images.githubusercontent.com/1786804/169152229-e06ff549-55fe-4149-8742-405446e6b01f.png)
 
-Currently, DisplayCAL is working with Python 3.8, 3.9, 3.10 and 3.11 and wxPython 4.1.1 to 4.2.1.
+Currently, DisplayCAL is working with Python 3.8 to 3.12 and wxPython 4.1.1 to 4.2.1.
 
 Here is a list of things that is working:
 
@@ -66,6 +66,7 @@ Prerequisites:
 * gtk-3
 * libXxf86vm
 * pkg-config
+* python3-devel
 
 Please install these from your package manager. 
 
@@ -77,7 +78,7 @@ brew install glib gtk+3 python@3.10
 apt-get install build-essential dbus libglib2.0-dev pkg-config libgtk-3-dev libxxf86vm-dev
 
 # Fedora core installs
-dnf install gcc glibc-devel dbus pkgconf gtk3-devel libXxf86vm-devel
+dnf install gcc glibc-devel dbus pkgconf gtk3-devel libXxf86vm-devel python3-devel
 ```
 
 Then pull the source:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ apt-get install build-essential dbus libglib2.0-dev pkg-config libgtk-3-dev libx
 dnf install gcc glibc-devel dbus pkgconf gtk3-devel libXxf86vm-devel python3-devel
 ```
 
+Note, if your system's default python is outside the supported range you will need to install a supported version and its related devel package. 
+
 Then pull the source:
 
 ```shell
@@ -115,10 +117,10 @@ Manually Setup
 --------------
 
 If the `makefile` workflow doesn't work for you, you can setup the virtual environment
-manually:
+manually. Ensure the python binary you're using is supported:
 
 ```shell
-python -m venv .venv
+python -m venv .venv # python3.12 -m venv .venv if system python is not a supported version
 source .venv/bin/activate  # Windows: .venv\Scripts\activate.bat
 pip install -r requirements.txt
 python -m build

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ Then you can build and install DisplayCAL using:
 make build
 make install
 ```
+The build step assumes your system has a python3 binary available that is within the correct range. If your system python3 is not supported and you installed a new one, you can try passing it to the build command.
+eg
+
+```shell
+$ python3 --version
+# Python 3.13.0
+make build # this will fail
+$ python3.12 --version
+# Python 3.12.2
+make SYSTEM_PYTHON=python3.12 build # should work
+```
 
 If this errors out for you, you can follow the [Manual Setup](https://github.com/eoyilmaz/displaycal-py3#manually-setup)
 section below.


### PR DESCRIPTION
While trying to set this up today on Fedora 39 I hit a few issues which were mostly addressed in replies to various issues.

Just writing up a couple of key gotchas that seem to hit a few people.
- Need to install python3-devel.
   - Added only to Fedora reqs as I don't have a Debian install to test at present.
   - OSX doesn't seem to require anything special it worked out of the box.
- Notes about supported python versions
   - Updated the support range to highlight 3.12 works now (based on the fact that it works for me, and that recent commits in develop enabled it)
   - Updated the notes around failing back to manual install and using the correct python version to setup the venv 
   - Documented use of new Makefile variable (see below)

Also added a new Makefile variable SYSTEM_PYTHON which defaults to python3 as it already did, but now can be overridden with a different python binary to call the venv. Once this is setup it seems like it just works.