### PR TITLE
Updated Argyll CMS from V3.1.0 to V3.2.0

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -533,7 +533,7 @@ def app_update_confirm(
         #       we don't have access to displaycal.net to update the ArgylCMS
         #       version. So, this mechanism should be updated to use some
         #       other way of getting newer app versions...
-        newversion = "3.1.0"
+        newversion = "3.2.0"
     else:
         newversion_desc = appname
     newversion_desc += f" {newversion}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,16 +56,16 @@ def argyll():
     can not find it, it will download from the source.
     """
     argyll_download_url = {
-        "win32": "https://www.argyllcms.com/Argyll_V3.1.0_win64_exe.zip",
-        "darwin": "https://www.argyllcms.com/Argyll_V3.1.0_osx10.6_x86_64_bin.tgz",
-        "linux": "https://www.argyllcms.com/Argyll_V3.1.0_linux_x86_64_bin.tgz",
+        "win32": "https://www.argyllcms.com/Argyll_V3.2.0_win64_exe.zip",
+        "darwin": "https://www.argyllcms.com/Argyll_V3.2.0_osx10.6_x86_64_bin.tgz",
+        "linux": "https://www.argyllcms.com/Argyll_V3.2.0_linux_x86_64_bin.tgz",
     }
 
     # first look in to ~/local/bin/ArgyllCMS
     home = pathlib.Path().home()
     argyll_search_paths = [
         home / ".local" / "bin" / "Argyll" / "bin",
-        home / ".local" / "bin" / "Argyll_V3.1.0" / "bin",
+        home / ".local" / "bin" / "Argyll_V3.2.0" / "bin",
     ]
 
     argyll_path = None
@@ -108,7 +108,7 @@ def argyll():
         shutil.rmtree(argyll_temp_path)
         os.chdir(current_working_directory)
 
-    argyll_path = pathlib.Path(argyll_temp_path) / "Argyll_V3.1.0" / "bin"
+    argyll_path = pathlib.Path(argyll_temp_path) / "Argyll_V3.2.0" / "bin"
     print(f"argyll_path: {argyll_path}")
     if argyll_path.is_dir():
         setcfg("argyll.dir", str(argyll_path.absolute()))


### PR DESCRIPTION
I think these are all the places I should make edits to in order to update DisplayCAL to be able to use Argyll CMS v3.2.0 when launching instead of v3.1.0, but please let me know if I've missed some.