### PR TITLE
Updated ArgyllCMS to 3.3.0

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -534,7 +534,7 @@ def app_update_confirm(
         #       we don't have access to displaycal.net to update the ArgylCMS
         #       version. So, this mechanism should be updated to use some
         #       other way of getting newer app versions...
-        newversion = "3.2.0"
+        newversion = "3.3.0"
     else:
         newversion_desc = appname
     newversion_desc += f" {newversion}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,16 +56,16 @@ def argyll():
     can not find it, it will download from the source.
     """
     argyll_download_url = {
-        "win32": "https://www.argyllcms.com/Argyll_V3.2.0_win64_exe.zip",
-        "darwin": "https://www.argyllcms.com/Argyll_V3.2.0_osx10.6_x86_64_bin.tgz",
-        "linux": "https://www.argyllcms.com/Argyll_V3.2.0_linux_x86_64_bin.tgz",
+        "win32": "https://www.argyllcms.com/Argyll_V3.3.0_win64_exe.zip",
+        "darwin": "https://www.argyllcms.com/Argyll_V3.3.0_osx10.6_x86_64_bin.tgz",
+        "linux": "https://www.argyllcms.com/Argyll_V3.3.0_linux_x86_64_bin.tgz",
     }
 
     # first look in to ~/local/bin/ArgyllCMS
     home = pathlib.Path().home()
     argyll_search_paths = [
         home / ".local" / "bin" / "Argyll" / "bin",
-        home / ".local" / "bin" / "Argyll_V3.2.0" / "bin",
+        home / ".local" / "bin" / "Argyll_V3.3.0" / "bin",
     ]
 
     argyll_path = None
@@ -108,7 +108,7 @@ def argyll():
         shutil.rmtree(argyll_temp_path)
         os.chdir(current_working_directory)
 
-    argyll_path = pathlib.Path(argyll_temp_path) / "Argyll_V3.2.0" / "bin"
+    argyll_path = pathlib.Path(argyll_temp_path) / "Argyll_V3.3.0" / "bin"
     print(f"argyll_path: {argyll_path}")
     if argyll_path.is_dir():
         setcfg("argyll.dir", str(argyll_path.absolute()))


### PR DESCRIPTION
I saw this on the release page "Updated Argyll CMS from V3.1.0 to V3.2.0 (v3.3.0 is already released, so it is left to the users to download)." and even though it's too late for this to reach 3.9.13 release now, maybe it will stay ArgyllCMS 3.3.0 for a while now, and next release 3.9.14 people won't have to download newest ArgyllCMS by themselves, unpack it and store it in a location and let DisplayCAL find it, maybe for now DIsplayCAL can take care of it self.