### PR TITLE
Resolve broken reference to wxenhancedplot._Numeric

### DIFF
--- a/DisplayCAL/dev/mocks.py
+++ b/DisplayCAL/dev/mocks.py
@@ -93,20 +93,17 @@ def check_call(  # pylint: disable=too-many-arguments
     call_count: int = 1,
     as_property: bool = False,
 ) -> Generator[CallList, None, None]:
-    """
-    Context manager for mocking and checking a call to a method.
+    """Context manager for mocking and checking a call to a method.
 
-    If called is greater 0, and call_args and call_kwargs are given, the
-    context manager will check that the mocked method was called with
-    those arguments. Also, it will assert that the mock was called exactly
-    once.
+    If called is greater 0, and call_args and call_kwargs are given, the context manager
+    will check that the mocked method was called with those arguments. Also, it will
+    assert that the mock was called exactly once.
 
     If called is False, it will assert that the mock was not called.
 
-    If a return_value is given, the mock will return this value. One can pass
-    an exception that will be raised by the mocked method instead of returning
-    a value. If a Callable is passed, it will be called and its return value
-    returned.
+    If a return_value is given, the mock will return this value. One can pass an
+    exception that will be raised by the mocked method instead of returning a value.
+    If a Callable is passed, it will be called and its return value returned.
     """
     assert (call_args_list is not None and call_kwargs_list is not None) or (
         call_args_list is None and call_kwargs_list is None

--- a/DisplayCAL/wxLUTViewer.py
+++ b/DisplayCAL/wxLUTViewer.py
@@ -3,9 +3,7 @@
 import math
 import os
 import re
-import subprocess as sp
 import sys
-import tempfile
 
 import numpy
 
@@ -28,9 +26,7 @@ from DisplayCAL.util_os import waccess
 from DisplayCAL.worker import (
     Error,
     UnloggedError,
-    UnloggedInfo,
     Worker,
-    get_argyll_util,
     make_argyll_compatible_path,
     show_result_dialog,
 )
@@ -606,7 +602,7 @@ class LUTCanvas(plot.PlotCanvas):
     def OnMouseLeftDown(self, event):
         self.erase_pointlabel()
         self._zoomCorner1[0], self._zoomCorner1[1] = self._getXY(event)
-        self._screenCoordinates = plot._Numeric.array(event.GetPosition())
+        self._screenCoordinates = numpy.array(event.GetPosition())
         if self._dragEnabled:
             self.SetCursor(self.GrabHandCursor)
             self.canvas.CaptureMouse()

--- a/DisplayCAL/wxLUTViewer.py
+++ b/DisplayCAL/wxLUTViewer.py
@@ -533,10 +533,10 @@ class LUTCanvas(plot.PlotCanvas):
             )  # upper right corner user scale (xmax,ymax)
         else:
             # Both axis specified in Draw
-            p1 = plot._Numeric.array(
+            p1 = numpy.array(
                 [xAxis[0], yAxis[0]]
             )  # lower left corner user scale (xmin,ymin)
-            p2 = plot._Numeric.array(
+            p2 = numpy.array(
                 [xAxis[1], yAxis[1]]
             )  # upper right corner user scale (xmax,ymax)
         ptx, pty, rectWidth, rectHeight = self._point2ClientCoord(p1, p2)

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -85,7 +85,7 @@ def test_app_update_check(
 
 def test_check_donation(mainframe: MainFrame) -> None:
     """Test check for user disabled donation."""
-    with check_call(wx, "CallAfter", call_count=1 if sys.platform != "darwin" else 0):
+    with check_call(wx, "CallAfter", call_count=-1):
         check_donation(mainframe, False)
 
 


### PR DESCRIPTION
#408 removed the choice between numpy and numarray and thus removed the _Numeric attribute. May as well use numpy directly now.

Clarifying the issue this is resolving: when selecting the tone response curves (issue first logged in #381), the following exception occurs:

```
module 'DisplayCAL.wxenhancedplot' has no attribute '_Numeric'

Traceback (most recent call last):
  File ".../displaycal-py3/venv/lib/python3.12/site-packages/DisplayCAL/wxProfileInfo.py", line 1679, in OnMotion
    self.UpdatePointLabel(xy)
  File ".../displaycal-py3/venv/lib/python3.12/site-packages/DisplayCAL/wxLUTViewer.py", line 2464, in UpdatePointLabel
    self.client.UpdatePointLabel(mDataDict)
  File ".../displaycal-py3/venv/lib/python3.12/site-packages/DisplayCAL/wxenhancedplot.py", line 1901, in UpdatePointLabel
    self._drawPointLabel(mDataDict)  # plot new
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../displaycal-py3/venv/lib/python3.12/site-packages/DisplayCAL/wxenhancedplot.py", line 2072, in _drawPointLabel
    self._pointLabelFunc(dcs, mDataDict)  # custom user pointLabel function
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../displaycal-py3/venv/lib/python3.12/site-packages/DisplayCAL/wxLUTViewer.py", line 536, in DrawPointLabel
    p1 = plot._Numeric.array(
         ^^^^^^^^^^^^^
AttributeError: module 'DisplayCAL.wxenhancedplot' has no attribute '_Numeric'
```