### PR TITLE
Further improvement and bugfixes for the colorimeter correction workflow

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -12700,7 +12700,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                         if debug or verbose >= 2:
                             print("cgats_observer =", cgats_observer)
                         if (
-                            cgats_instrument != instrument
+                            cgats_instrument.decode("utf-8") != instrument
                             or cgats_measurement_mode != measurement_mode
                             or cgats_observer.decode("utf-8") != observer
                         ):

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -12668,6 +12668,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                                 cgats_measurement_mode += "V"
                             if (
                                 instrument_features.get("highres_mode")
+                                and cgats.queryv1("SPECTRAL_BANDS") is not None
                                 and cgats.queryv1("SPECTRAL_BANDS") > 36
                             ):
                                 cgats_measurement_mode += "H"

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -12785,6 +12785,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             )
             if defaultFile:
                 dlg.reference_ti3.SetPath(os.path.join(defaultDir, defaultFile))
+                wx.CallAfter(dlg.reference_ti3.setupControl)
             dlg.reference_ti3.changeCallback = check_last_ccxx_ti3
             dlg.reference_ti3.SetMaxFontSize(11)
             dlg.reference_ti3_droptarget = FileDrop(dlg)
@@ -12909,6 +12910,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             )
             if defaultFile:
                 dlg.colorimeter_ti3.SetPath(os.path.join(defaultDir, defaultFile))
+                wx.CallAfter(dlg.colorimeter_ti3.setupControl)
             dlg.colorimeter_ti3.changeCallback = check_last_ccxx_ti3
             dlg.colorimeter_ti3.SetMaxFontSize(11)
             dlg.colorimeter_ti3_droptarget = FileDrop(dlg)

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -13757,7 +13757,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 white_abs = []
                 for _j, meas in enumerate((reference_ti3, colorimeter_ti3)):
                     # Get absolute whitepoint
-                    white = meas.queryv1("LUMINANCE_XYZ_CDM2") or meas.queryi1(
+                    white = meas.queryv1("LUMINANCE_XYZ_CDM2").decode("utf-8") or meas.queryi1(
                         {"RGB_R": 100, "RGB_G": 100, "RGB_B": 100}
                     )
                     if isinstance(white, str):


### PR DESCRIPTION
1. **Bugfix**: If only a spectrometer is currently connected, when `check_last_ccxx_ti3` runs for the second time to check the colorimeter .ti3, it no longer throws an error since the colorimeter file doesn't contain spectral data. Found this will working away from my desk, without a USB hub, and swapping between instruments.
2. **Bugfix**: While looking through `check_last_ccxx_ti3`, I noticed that the instrument names never matched. It just needed to be decoded and now the little green checkmark will display properly.
3. **Improvement**: Both .ti3 path dropdowns now properly select and show the most recent file when the window is opened. This had really bugged me for a while as a UX problem. Both would show as empty and blank when the window opens, even though the files were programmatically selected. The "Create colorimeter correction..." button would be enabled too, but at first glance, the user could not tell why or what would be used to create a correction if clicked. Also, after taking a new measurement, the user would not be shown that the new measurement was being applied. Now the most recent files are clearly shown, which makes the process more apparent to the user. Note that using `wx.CallAfter` does mean the dropdowns show as blank for a split second in the GUI before the filenames are loaded, but I think this is definitely worth the UX improvement.
4. **Bugfix**: The white luminance values from both .ti3 files are now properly decoded. This means the xyY and dE values that DisplayCal shows in the GUI as the last step of the correction process and then writes to the metadata of the .ccmx file are correct and accurate to the measured values from both instruments. I confirmed that this does not affect the actual correction matrix, as that is created directly by Argyll `ccmxmake`. So any corrections created before this was fixed are still accurate. Just the dE metadata would have been inaccurate.