### PR TITLE
Additional fixes for #67 and #31

### DIFF
--- a/DisplayCAL/wxLUTViewer.py
+++ b/DisplayCAL/wxLUTViewer.py
@@ -1343,6 +1343,10 @@ class LUTFrame(BaseFrame):
         elif profile.connectionColorSpace == b"RGB":
             direction = "f"
         elif "B2A0" in profile.tags:
+            index = self.direction_select.GetSelection()
+            if index == -1:  # Fix for #31
+                index = 0
+                self.direction_select.SetSelection(index)
             direction = {0: "b", 1: "if", 2: "f", 3: "ib"}.get(
                 self.direction_select.GetSelection()
             )

--- a/DisplayCAL/wxProfileInfo.py
+++ b/DisplayCAL/wxProfileInfo.py
@@ -975,6 +975,10 @@ class GamutViewOptions(wx_Panel):
 
     @property
     def direction(self):
+        index = self.direction_select.GetSelection()
+        if index == -1:  # Fix for #67
+            index = 0
+            self.direction_select.SetSelection(index)
         if self.direction_select.IsShown():
             return {0: "f", 1: "ib"}.get(self.direction_select.GetSelection())
         else:


### PR DESCRIPTION
I noticed that #434 didn't fully fix the issue for me.

For #67, I just added @eoyilmaz's same fix for the `direction_select` dropdown as well.
From [your screenshot in this comment](https://github.com/eoyilmaz/displaycal-py3/issues/67#issuecomment-2416889717), it looks like you loaded a profile that didn't have the LUT checkbox enabled, so setting a default for the direction wouldn't have come up. No big deal.

For #31, even after the above fix, I was still getting the `can only concatenate str (not "NoneType") to str` GUI error. I eventually found that this error was coming from within the `LUTFrame` class, which just needed the same fix so `direction` has a default value there too.