### PR TITLE
A quick fix in the test chart editor

### DIFF
--- a/DisplayCAL/wxTestchartEditor.py
+++ b/DisplayCAL/wxTestchartEditor.py
@@ -2434,7 +2434,7 @@ END_DATA"""
     def tc_precond_handler(self, event=None):
         setcfg("tc_precond", int(self.tc_precond.GetValue()))
         self.tc_adaption_slider.SetValue(
-            (1 if getcfg("tc_precond") else defaults["tc_adaption"]) * 100
+            int((1 if getcfg("tc_precond") else defaults["tc_adaption"]) * 100)
         )
         self.tc_adaption_handler(self.tc_adaption_slider)
         self.tc_algo_handler()


### PR DESCRIPTION
Found this by accident while digging around to fix something else.
When the Preconditioning profile checkbox is first checked, it updates the Adaptation slider value to 100.
When the checkbox is unchecked, it now properly resets the Adaptation slider to its default value of 10, instead of throwing a `float` vs. `int` error.