### PR TITLE
Update install_instructions_linux.md

### DIFF
--- a/docs/install_instructions_linux.md
+++ b/docs/install_instructions_linux.md
@@ -50,7 +50,7 @@ Create a virtual environment:
 ```shell
 cd ~
 python -m venv venv-displaycal
-source venv-diplaycal/bin/activate
+source venv-displaycal/bin/activate
 pip install displaycal
 ```
 


### PR DESCRIPTION
Fixed a typo in the command for activating the virtual environment. The install_instructions_linux.md previously instructed users to activate 'venv-diplaycal', which was incorrect. Updated to 'venv-displaycal' to match the created virtual environment name.