### PR TITLE
455 displaycal 3914 for windows error when poweroff or restart compoter

### DIFF
--- a/DisplayCAL/meta.py
+++ b/DisplayCAL/meta.py
@@ -65,7 +65,7 @@ version_short = re.sub(r"(?:\.0){1,2}$", "", version)
 version_tuple = VERSION  # only ints allowed and must be exactly 3 values
 
 wx_minversion = (2, 8, 11)
-wx_recversion = (4, 2, 2)
+wx_recversion = (4, 2, 0)
 
 
 def get_latest_changelog_entry(readme):

--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -224,9 +224,9 @@ def setup_profile_loader_task(exe, exedir, pydir):
                 exception,
             )
             if ts.stdout:
-                print(str(ts.stdout, enc))
+                print(str(ts.stdout, encoding=enc, errors="replace"))
         else:
-            print(str(ts.stdout, enc))
+            print(str(ts.stdout, encoding=enc, errors="replace"))
             if created:
                 # Remove autostart entries, if any
                 name = f"{appname} Profile Loader"
@@ -259,9 +259,9 @@ def setup_profile_loader_task(exe, exedir, pydir):
             exception,
         )
         if ts.stdout:
-            print(str(ts.stdout))
+            print(str(ts.stdout, encoding=enc, errors="replace"))
     else:
-        print(str(ts.stdout))
+        print(str(ts.stdout, encoding=enc, errors="replace"))
     print("setup_profile_loader_task end 4")
 
 


### PR DESCRIPTION
- Fixed `DisplayCAL.taskscheduler.TaskScheduler.__str__()` not to recurse.
- Fixed `DisplayCAL.profile_loader` to properly printout `TaskScheduler` output.
- Downgraded the required `wxPython` version to `4.2.0` to fix DisplayCAL complaining about `wxPython=4.2.1` is deprecated, which is not...