### PR TITLE
Windows specific fixes for various feature

### DIFF
--- a/DisplayCAL/icc_profile.py
+++ b/DisplayCAL/icc_profile.py
@@ -102,6 +102,7 @@ COLOR_PROFILE_TYPE = {"ICC": 0, "DMP": 1, "CAMP": 2, "GMMP": 3}
 WCS_PROFILE_MANAGEMENT_SCOPE = {"SYSTEM_WIDE": 0, "CURRENT_USER": 1}
 
 ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE = 2015
+ERROR_SUCCESS = 0
 
 DEBUG = False
 
@@ -2479,11 +2480,13 @@ def _wcs_set_display_profile(
     # also set its video card gamma ramps to linear if Windows calibration
     # management isn't enabled.
     _win10_1903_take_process_handles_snapshot()
-    mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
-    retv = mscms.WcsAssociateColorProfileWithDevice(scope, profile_name, devicekey)
-    _win10_1903_close_leaked_regkey_handles(devicekey)
-    if not retv:
-        raise util_win.get_windows_error(ctypes.windll.kernel32.GetLastError())
+    try:
+        mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
+        retv = mscms.WcsAssociateColorProfileWithDevice(scope, profile_name, devicekey)
+        if not retv:
+            raise util_win.get_windows_error(ctypes.windll.kernel32.GetLastError())
+    finally:
+        _win10_1903_close_leaked_regkey_handles(devicekey)
     monkey = devicekey.split("\\")[-2:]
     current_user = scope == WCS_PROFILE_MANAGEMENT_SCOPE["CURRENT_USER"]
     profiles = _winreg_get_display_profiles(monkey, current_user)
@@ -2517,20 +2520,22 @@ def _wcs_unset_display_profile(
     current_user = scope == WCS_PROFILE_MANAGEMENT_SCOPE["CURRENT_USER"]
     profiles = _winreg_get_display_profiles(monkey, current_user)
     _win10_1903_take_process_handles_snapshot()
-    retv = mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
-    _win10_1903_close_leaked_regkey_handles(devicekey)
-    if not retv:
-        errcode = ctypes.windll.kernel32.GetLastError()
-        if (
-            errcode == ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE
-            and profile_name in profiles
-        ):
-            # Check if profile is still associated
-            profiles = _winreg_get_display_profiles(monkey, current_user)
-            if profile_name not in profiles:
-                # Successfully disassociated
-                return True
-        raise util_win.get_windows_error(errcode)
+    try:
+        retv = mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
+        if not retv:
+            errcode = ctypes.windll.kernel32.GetLastError()
+            if (
+                errcode in (ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE, ERROR_SUCCESS)
+                and profile_name in profiles
+            ):
+                # Check if profile is still associated
+                profiles = _winreg_get_display_profiles(monkey, current_user)
+                if profile_name not in profiles:
+                    # Successfully disassociated
+                    return True
+            raise util_win.get_windows_error(errcode)
+    finally:
+        _win10_1903_close_leaked_regkey_handles(devicekey)
     return True
 
 

--- a/DisplayCAL/icc_profile.py
+++ b/DisplayCAL/icc_profile.py
@@ -2175,7 +2175,7 @@ def _winreg_get_display_profiles(monkey, current_user=False):
         numsubkeys, numvalues, mtime = winreg.QueryInfoKey(key)
         for i in range(numvalues):
             name, value, type_ = winreg.EnumValue(key, i)
-            if name != "ICMProfile" or not value:
+            if name != "ICMProfileAC" or not value:
                 continue
 
             if type_ == winreg.REG_BINARY:

--- a/DisplayCAL/icc_profile.py
+++ b/DisplayCAL/icc_profile.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import binascii
+import contextlib
 import ctypes
 import datetime
 import json
@@ -2176,7 +2177,7 @@ def _winreg_get_display_profiles(monkey, current_user=False):
         numsubkeys, numvalues, mtime = winreg.QueryInfoKey(key)
         for i in range(numvalues):
             name, value, type_ = winreg.EnumValue(key, i)
-            if name != "ICMProfileAC" or not value:
+            if name not in ["ICMProfile", "ICMProfileAC"] or not value:
                 continue
 
             if type_ == winreg.REG_BINARY:
@@ -2480,13 +2481,17 @@ def _wcs_set_display_profile(
     # also set its video card gamma ramps to linear if Windows calibration
     # management isn't enabled.
     _win10_1903_take_process_handles_snapshot()
-    try:
+    with contextlib.suppress(WindowsError):
+        # Disassociate the profile from the device first
         mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
+    try:
+        # Associate the profile with the device
         retv = mscms.WcsAssociateColorProfileWithDevice(scope, profile_name, devicekey)
-        if not retv:
-            raise util_win.get_windows_error(ctypes.windll.kernel32.GetLastError())
-    finally:
-        _win10_1903_close_leaked_regkey_handles(devicekey)
+    except WindowsError:
+        retv = None
+    _win10_1903_close_leaked_regkey_handles(devicekey)
+    if not retv:
+        raise util_win.get_windows_error(ctypes.windll.kernel32.GetLastError())
     monkey = devicekey.split("\\")[-2:]
     current_user = scope == WCS_PROFILE_MANAGEMENT_SCOPE["CURRENT_USER"]
     profiles = _winreg_get_display_profiles(monkey, current_user)
@@ -2521,21 +2526,23 @@ def _wcs_unset_display_profile(
     profiles = _winreg_get_display_profiles(monkey, current_user)
     _win10_1903_take_process_handles_snapshot()
     try:
+        # Disassociate the profile from the device
         retv = mscms.WcsDisassociateColorProfileFromDevice(scope, profile_name, devicekey)
-        if not retv:
-            errcode = ctypes.windll.kernel32.GetLastError()
-            if (
-                errcode in (ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE, ERROR_SUCCESS)
-                and profile_name in profiles
-            ):
-                # Check if profile is still associated
-                profiles = _winreg_get_display_profiles(monkey, current_user)
-                if profile_name not in profiles:
-                    # Successfully disassociated
-                    return True
-            raise util_win.get_windows_error(errcode)
-    finally:
-        _win10_1903_close_leaked_regkey_handles(devicekey)
+    except WindowsError:
+        retv = None
+    _win10_1903_close_leaked_regkey_handles(devicekey)
+    if not retv:
+        errcode = ctypes.windll.kernel32.GetLastError()
+        if (
+            errcode in (ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE, ERROR_SUCCESS)
+            and profile_name in profiles
+        ):
+            # Check if profile is still associated
+            profiles = _winreg_get_display_profiles(monkey, current_user)
+            if profile_name not in profiles:
+                # Successfully disassociated
+                return True
+        raise util_win.get_windows_error(errcode)
     return True
 
 

--- a/DisplayCAL/lang/ru.yaml
+++ b/DisplayCAL/lang/ru.yaml
@@ -1625,7 +1625,7 @@
 "measureframe.measurebutton": |-
   Начать измерения
 "measureframe.title": |-
-  Площадь измерений
+  Область измерений
 "measureframe.zoomin": |-
   Увеличить
 "measureframe.zoommax": |-
@@ -2056,7 +2056,7 @@
 "profile_loader": |-
   Загрузчик профиля
 "profile_loader.disable": |-
-  Виключить загрузку профиля
+  Выключить загрузку профиля
 "profile_loader.exceptions.known_app.error": |-
   Загрузчик профиля автоматически выключается, когда %s работает. Вы не можете изменить это поведение.
 "profile_loader.exit_warning": |-

--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -467,7 +467,7 @@ class ProfileLoaderExceptionsDialog(ConfirmDialog):
             style = wx.BORDER_SIMPLE
         else:
             style = wx.BORDER_THEME
-        dlg.grid = CustomGrid(dlg, -1, size=(648 * scale, 200 * scale), style=style)
+        dlg.grid = CustomGrid(dlg, -1, size=wx.Size(int(648 * scale), int(200 * scale)), style=style)
         grid = dlg.grid
         grid.DisableDragRowSize()
         grid.SetCellHighlightPenWidth(0)
@@ -505,7 +505,7 @@ class ProfileLoaderExceptionsDialog(ConfirmDialog):
             else:
                 # Directory component
                 size = dc.GetTextExtent("W" * 34)[0]
-            grid.SetColSize(i, size)
+            grid.SetColSize(i, int(size))
         for i, label in enumerate(["", "", "executable", "directory"]):
             grid.SetColLabelValue(i, lang.getstr(label))
 

--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -315,7 +315,7 @@ class DisplayIdentificationFrame(wx.Frame):
         text = wx.StaticText(panel_inner, -1, label, style=wx.ALIGN_CENTER)
         text.ForegroundColour = "#FFFFFF"
         font = wx.Font(
-            text.Font.PointSize * size[0] / 12.0 / 16,
+            int(text.Font.PointSize * size[0] / 12.0 / 16),
             wx.FONTFAMILY_DEFAULT,
             wx.FONTSTYLE_NORMAL,
             wx.FONTWEIGHT_LIGHT,

--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -930,8 +930,8 @@ class ProfileAssociationsDialog(InfoDialog):
                 m_left, m_top, m_right, m_bottom = moninfo["Monitor"]
                 m_width = abs(m_right - m_left)
                 m_height = abs(m_bottom - m_top)
-                pos = m_left + m_width / 4, m_top + m_height / 4
-                size = (m_width / 2, m_height / 2)
+                pos = wx.Point(int(m_left + m_width / 4), int(m_top + m_height / 4))
+                size = wx.Size(int(m_width / 2), int(m_height / 2))
                 display_desc = display.replace(
                     "[PRIMARY]", lang.getstr("display.primary")
                 )

--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -16689,8 +16689,10 @@ BEGIN_DATA
                 args.append(cal_path)
             if getcfg("extra_args.dispread").strip():
                 args += parse_argument_string(getcfg("extra_args.dispread"))
+        if sys.platform == "win32":
+            args = quote_args(args)
         result = self.add_measurement_features(
-            quote_args(args) if sys.platform == "win32" else args,
+            args,
             cmd == get_argyll_util("dispread"),
             allow_nondefault_observer=is_ccxx_testchart(),
             allow_video_levels=allow_video_levels,


### PR DESCRIPTION
### Fixes
- Profile loader:
    + "Identify display" feature was crashing on load due to type issues during frame creation
    + "Identify display" feature had wrong placement and size once again due to type issues
    +  display associated profiles was only listing the default profile for display (wrong registry key parsed)
    + "Exceptions" dialogue was crashing on launch due to type issues
    + display association through mscms.dll kept causing errors during operations, even though they actually succeded (GetLastError returns success). This is more of a band-aid solution really, but I think this is just a quirk of the API
- DisplayCal:
    + dispread was not receiving part of the parameters. It is a somewhat subtle bug: add_measurement_features was mutating a temporary list. This is a windows specific issue. That caused calibration to work correctly only on single monitor configurations