### PR TITLE
585 displaycal can not start after first install

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -4692,7 +4692,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
 
                 item_text = "{}: {}".format(
                     types.get(os.path.splitext(path)[1].lower()[1:]),
-                    desc if isinstance(desc, str) else desc.decode("utf-8"),
+                    desc if isinstance(desc, str) else desc.decode("utf-8", "replace"),
                 )
                 items.append(item_text)
                 self.ccmx_item_paths.append(path)
@@ -4807,7 +4807,9 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     2,
                     "{}: {}".format(
                         types.get(os.path.splitext(ccmx[1])[1].lower()[1:]),
-                        desc if isinstance(desc, str) else desc.decode("utf-8"),
+                        desc
+                        if isinstance(desc, str)
+                        else desc.decode("utf-8", "replace"),
                     ),
                 )
                 self.ccmx_item_paths.insert(0, ccmx[1])
@@ -4856,7 +4858,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     (
                         ccmx_desc
                         if isinstance(ccmx_desc, str)
-                        else ccmx_desc.decode("utf-8")
+                        else ccmx_desc.decode("utf-8", "replace")
                     ),
                 )
             else:

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -4636,7 +4636,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     continue
                 if desc == lstr:
                     desc = cgats.get_descriptor()  # this is bytes
-                    desc = desc.decode("utf-8")
+                    desc = desc.decode("utf-8", "replace")
                 # If the description is not the same as the 'sane'
                 # filename, add the filename after the description
                 # (max 31 chars)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -542,7 +542,7 @@ def test_get_argyll_latest_version_returns_str():
 def test_get_argyll_latest_version_returns_latest_argyll_cms_version():
     """get_argyll_latest_version() returns the latest argyll cms version."""
     result = get_argyll_latest_version()
-    assert result == "3.4.0"
+    assert result == "3.4.1"
 
 
 def test_get_argyll_latest_version_returns_the_default_version_if_no_internet_connect(


### PR DESCRIPTION
Fixed a couple of `utf-8` decoding issues with the `desc` field in `DisplayCAL.display_cal` module that might arise.