### PR TITLE
Fix crash in demjson_compat.py

### DIFF
--- a/DisplayCAL/demjson_compat.py
+++ b/DisplayCAL/demjson_compat.py
@@ -113,7 +113,7 @@ def decode(txt, strict=False, encoding=None, **kw):
             sys.stdout.write("\n")
             print("JSON:", txt)
 
-    return json.loads(txt, encoding=encoding, strict=strict)
+    return json.loads(txt, strict=strict)
 
 
 def encode(obj, strict=False, compactly=True, escape_unicode=False, encoding=None):
@@ -155,5 +155,4 @@ def encode(obj, strict=False, compactly=True, escape_unicode=False, encoding=Non
         ensure_ascii=ensure_ascii,
         indent=indent,
         separators=separators,
-        encoding=encoding or "utf-8",
     )


### PR DESCRIPTION
This pull request makes minor compatibility updates to the `DisplayCAL/demjson_compat.py` file, specifically removing the use of the deprecated `encoding` parameter from calls to the `json` library.

* Removed the `encoding` parameter from the `json.loads` call in the `decode` function to ensure compatibility with newer versions of Python's `json` module.
* Removed the `encoding` parameter from the `json.dumps` call in the `encode` function, as it is no longer supported or necessary.

Please note, I am new to this project. So please let me know if there are any contribution guidelines that I missed.
I have tested this locally, and it seems to resolve #637.

Feedback welcome!