### PR TITLE
Fix installer DefaultDirName to use {sd} instead of {pf} to avoid spa…

### DIFF
--- a/misc/DisplayCAL-Setup-py2exe.iss
+++ b/misc/DisplayCAL-Setup-py2exe.iss
@@ -16,7 +16,7 @@ AppSupportURL=%(AppSupportURL)s
 AppUpdatesURL=%(AppUpdatesURL)s
 ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
-DefaultDirName={pf}\%(AppName)s
+DefaultDirName={sd}\%(AppName)s
 DefaultGroupName=%(AppName)s
 LicenseFile=..\LICENSE.txt
 OutputDir=.
@@ -114,6 +114,26 @@ MinVersion: 0,6.0; Filename: schtasks.exe; parameters: "/Delete /TN ""%(AppName)
 MinVersion: 0,6.0; Filename: schtasks.exe; parameters: "/Delete /TN ""%(AppName)s Profile Loader Launcher - Daily Restart"" /F"; Flags: RunHidden RunAsCurrentUser;
 
 [Code]
+function NextButtonClick(CurPageID: Integer): Boolean;
+var
+	InstallPath: String;
+begin
+	Result := True;
+	if CurPageID = wpSelectDir then
+	begin
+		InstallPath := WizardDirValue();
+		if Pos(' ', InstallPath) > 0 then
+		begin
+			MsgBox(
+				'The installation path cannot contain spaces.' + #13#10 + #13#10 +
+				'%(AppName)s will not work correctly when installed to a path containing spaces' + #13#10 +
+				'(e.g. "C:\Program Files\%(AppName)s").' + #13#10 + #13#10 +
+				'Please choose a path without spaces, such as:  C:\%(AppName)s',
+				mbError, MB_OK);
+			Result := False;
+		end;
+	end;
+end;
 function Get_RunEntryShellExec_Message(Value: string): string;
 begin
 	Result := FmtMessage(SetupMessage(msgRunEntryShellExec), [Value]);
@@ -157,3 +177,4 @@ begin
 		end;
 	end;
 end;
+


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h1 id="fix-windows-installer-defaults-to-a-path-containing-spaces-breaking-profiling" class="atx">Fix: Windows installer defaults to a path containing spaces, breaking profiling</h1>
<h2 id="problem" class="atx">Problem</h2>
<p>The Windows installer defaults <code>DefaultDirName</code> to <code>{pf}\%(AppName)s</code>, which
resolves to <code>C:\Program Files\DisplayCAL</code> — a path containing spaces — on every
Windows installation.</p>
<p>DisplayCAL breaks when run from a path with spaces because wexpect cannot correctly
pass DisplayCAL&#39;s own internal <code>ref/</code> file paths (e.g. <code>linear.cal</code>,
<code>verify_video.ti1</code>) as arguments to ArgyllCMS executables when those paths contain
spaces. The result is a silent failure at the profiling phase after a successful
hours-long calibration run, surfacing as:</p>
<pre><code class="fenced-code-block">argyll.util.not_found</code></pre>
<p>This affects every Windows user who clicks through the installer without changing
the default path.</p>
<h2 id="history-of-this-issue" class="atx">History of this issue</h2>
<p>This has been an open wound since the Windows installer shipped in 3.9.13:</p>
<ul>
<li><strong>3.9.13</strong>: Installer introduced. Spaces break everything. No warning.</li>
<li><strong>3.9.14</strong>: Manual warning added to release notes: *&quot;install DisplayCAL under
<code>C:\DisplayCAL</code> instead of <code>C:\Program Files\DisplayCAL</code>. There seems to be an
issue if the path contains empty spaces.&quot;*</li>
<li><strong>3.9.15</strong>: Release notes claimed *&quot;paths containing empty spaces are handled
correctly&quot;* — but <code>DefaultDirName</code> in the <code>.iss</code> template was never changed from
<code>{pf}</code>. The installer continued defaulting to <code>C:\Program Files\DisplayCAL</code>.</li>
<li><strong>3.9.17</strong>: *&quot;Fixed unnecessary argument quoting in
<code>DisplayCAL.wexpect.spawn_windows.__init__()</code>&quot;* — removing quotes that turned out
to still be necessary for spaced paths. Users on 3.9.17 with default installs
continued experiencing <code>argyll.util.not_found</code> at the profiling stage.</li>
</ul>
<p><strong>The <code>DefaultDirName</code> in <code>misc/DisplayCAL-Setup-py2exe.iss</code> has never been changed
from <code>{pf}</code> since the installer was introduced.</strong> This PR addresses that directly.</p>
<h2 id="fix" class="atx">Fix</h2>
<p>Two changes to <code>misc/DisplayCAL-Setup-py2exe.iss</code>. <code>setup.py</code> is unchanged — it
is only a template loader and handles <code>%(AppName)s</code> substitution automatically.</p>
<h3 id="1-change-the-default-install-directory-line-19" class="atx">1. Change the default install directory (line 19)</h3>
<pre><code class="fenced-code-block language-diff">-DefaultDirName={pf}\%(AppName)s
+DefaultDirName={sd}\%(AppName)s</code></pre>
<p><code>{pf}</code> resolves to <code>C:\Program Files</code> — guaranteed to contain a space on every
Windows installation. <code>{sd}</code> resolves to the Windows system drive root (e.g. <code>C:\</code>),
which is guaranteed space-free because Windows itself cannot be installed to a path
with spaces.</p>
<p><strong>On permissions:</strong> This installer already requires elevation via UAC. Any elevated
token that can write to <code>C:\Program Files</code> can equally write to <code>C:\DisplayCAL</code>.
The permission model is identical; <code>{sd}</code> is strictly safer, not more restrictive.</p>
<p>This single change fixes the problem for all users who click through the installer.</p>
<h3 id="2-add-nextbuttonclick-path-validation-to-the-code-section-after-line-116" class="atx">2. Add <code>NextButtonClick</code> path validation to the <code>[Code]</code> section (after line 116)</h3>
<p>Catches users who override the default and manually enter a path with spaces
(e.g. typing <code>C:\Program Files\DisplayCAL</code> back in). Merged into the existing
<code>[Code]</code> section — no second <code>[Code]</code> header.</p>
<pre><code class="fenced-code-block language-pascal">function NextButtonClick(CurPageID: Integer): Boolean;
var
    InstallPath: String;
begin
    Result := True;
    if CurPageID = wpSelectDir then
    begin
        InstallPath := WizardDirValue();
        if Pos(&#39; &#39;, InstallPath) &gt; 0 then
        begin
            MsgBox(
                &#39;The installation path cannot contain spaces.&#39; + #13#10 + #13#10 +
                &#39;%(AppName)s will not work correctly when installed to a path containing spaces&#39; + #13#10 +
                &#39;(e.g. &quot;C:\Program Files\%(AppName)s&quot;).&#39; + #13#10 + #13#10 +
                &#39;Please choose a path without spaces, such as:  C:\%(AppName)s&#39;,
                mbError, MB_OK);
            Result := False;
        end;
    end;
end;</code></pre>
<p><code>%(AppName)s</code> is substituted to <code>DisplayCAL</code> at build time by the existing
template mechanism in <code>setup.py</code>. <code>DisableDirPage</code> is not set in this template
(unlike the legacy 0install variants), so <code>NextButtonClick</code> will fire correctly.</p>
<h2 id="files-changed" class="atx">Files Changed</h2>

File | Change
-- | --
misc/DisplayCAL-Setup-py2exe.iss | Line 19: DefaultDirName + NextButtonClick merged into existing [Code]
setup.py | No changes


<h2 id="testing" class="atx">Testing</h2>
<ol>
<li>Run <code>python setup.py inno</code> — confirm generated <code>.iss</code> in <code>dist/</code> shows
<code>DefaultDirName={sd}\DisplayCAL</code></li>
<li>Compile with Inno Setup 6 and launch the installer</li>
<li>Confirm the default path offered is <code>C:\DisplayCAL</code></li>
<li>Override to a path with a space (e.g. <code>C:\My Programs\DisplayCAL</code>), click
Next — confirm the error dialog fires and blocks progression</li>
<li>Restore to a space-free path — confirm Next proceeds</li>
<li>Complete a full install and verify calibration + profiling succeeds end-to-end
without <code>argyll.util.not_found</code></li>
</ol>
<!--EndFragment-->
</body>
</html>