### PR TITLE
Fix post-profile reload when settings are marked changed.

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -12420,6 +12420,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     self.recent_cals.remove(cal)
                     self.calibration_file_ctrl.Delete(sel)
                 if options_dispcal and options_colprof:
+                    setcfg("settings.changed", 0)
                     self.load_cal_handler(
                         None,
                         path=profile_path,


### PR DESCRIPTION
Problem: DisplayCal would run the profiling, then the settings and profile wouldn't be saved.

Fix: Clear the changed flag right before internally reloading a newly created profile so calibration settings are applied to config instead of being skipped by the load guard.