### PR TITLE
[#701] Fix arch being None when setup.py inno runs standalone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -679,11 +679,12 @@ def setup():
                 print(f"inno_template_path: {inno_template_path}")
                 template = inno_template.read()
                 # print(template)
-                inno_arch = "x64" if arch == "amd64" else arch
+                inno_arch_raw = arch or get_platform().split("-")[1]
+                inno_arch = "x64" if inno_arch_raw == "amd64" else inno_arch_raw
                 inno_script = template % {
                     "AppCopyright": f"© {strftime('%Y')} {AUTHOR}",
                     "AppName": NAME,
-                    "AppArch": arch,
+                    "AppArch": inno_arch_raw,
                     "InnoArch": inno_arch,
                     "AppVerName": VERSION_STRING,
                     "AppPublisher": AUTHOR,


### PR DESCRIPTION
When invoked without a bdist command, arch was never set, causing %(InnoArch)s and %(AppArch)s to substitute as "None" and produce an invalid Inno Setup architecture identifier. Fall back to get_platform().split("-")[1] when arch is not set via --force-arch.