### PR TITLE
[#785] Isolate DisplayCAL user config from the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,12 @@ import tempfile
 # sits at the very top of this file, ahead of every other import.
 _TEST_HOME = tempfile.mkdtemp(prefix="displaycal-test-home-")
 os.environ["HOME"] = _TEST_HOME
-os.environ.setdefault("XDG_CACHE_HOME", os.path.join(_TEST_HOME, ".cache"))
-os.environ.setdefault("XDG_CONFIG_HOME", os.path.join(_TEST_HOME, ".config"))
-os.environ.setdefault("XDG_DATA_HOME", os.path.join(_TEST_HOME, ".local", "share"))
+# Force (not setdefault) these: CI runners (e.g. GitHub Actions) often already
+# export XDG_CONFIG_HOME/XDG_CACHE_HOME/XDG_DATA_HOME pointing outside
+# _TEST_HOME, which would defeat the isolation above.
+os.environ["XDG_CACHE_HOME"] = os.path.join(_TEST_HOME, ".cache")
+os.environ["XDG_CONFIG_HOME"] = os.path.join(_TEST_HOME, ".config")
+os.environ["XDG_DATA_HOME"] = os.path.join(_TEST_HOME, ".local", "share")
 if sys.platform == "win32":
     # Best-effort: the pywin32 SHGetSpecialFolderPath lookup DisplayCAL uses on
     # Windows queries the OS directly and ignores these, but the ctypes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,34 @@
-import glob
 import os
+import sys
+import tempfile
+
+# Isolate every DisplayCAL user path (preferences/config file, logs, storage,
+# cache, ...) under a throwaway per-session directory, so running the test
+# suite never reads from or writes to the developer's real config (e.g.
+# ~/Library/Preferences/DisplayCAL/DisplayCAL.ini on macOS, ~/.config/DisplayCAL
+# on Linux). DisplayCAL computes these paths from $HOME (and the XDG_* /
+# Windows equivalents) at *import time* (see DisplayCAL/defaultpaths.py), so
+# this must run before the first import of any DisplayCAL module — hence it
+# sits at the very top of this file, ahead of every other import.
+_TEST_HOME = tempfile.mkdtemp(prefix="displaycal-test-home-")
+os.environ["HOME"] = _TEST_HOME
+os.environ.setdefault("XDG_CACHE_HOME", os.path.join(_TEST_HOME, ".cache"))
+os.environ.setdefault("XDG_CONFIG_HOME", os.path.join(_TEST_HOME, ".config"))
+os.environ.setdefault("XDG_DATA_HOME", os.path.join(_TEST_HOME, ".local", "share"))
+if sys.platform == "win32":
+    # Best-effort: the pywin32 SHGetSpecialFolderPath lookup DisplayCAL uses on
+    # Windows queries the OS directly and ignores these, but the ctypes
+    # fallback and any other HOME-based logic still benefit.
+    os.environ["USERPROFILE"] = _TEST_HOME
+    os.environ.setdefault("APPDATA", os.path.join(_TEST_HOME, "AppData", "Roaming"))
+    os.environ.setdefault("LOCALAPPDATA", os.path.join(_TEST_HOME, "AppData", "Local"))
+
+import glob
 import platform
 import pathlib
 import shutil
 import subprocess
-import sys
 import tarfile
-import tempfile
 import time
 import zipfile
 


### PR DESCRIPTION
Tests were reading from and writing to the developer's real DisplayCAL config (e.g. ~/Library/Preferences/DisplayCAL/DisplayCAL.ini on macOS), since DisplayCAL computes its config/log/storage paths from $HOME at import time. Config written by one test run (or ad hoc debugging) was then picked up as the "default" baseline by later runs, causing flaky failures that looked like environment/ordering issues.

`tests/conftest.py` now overrides `HOME` (and the XDG_*/Windows equivalents) to a throwaway `tempfile.mkdtemp()` directory before any `DisplayCAL` import, so the whole suite runs against an isolated, disposable config every time.