### PR TITLE
Fix bytes/str bugs in colorimeter-correction web-check and upload

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -1068,6 +1068,16 @@ def colorimeter_correction_web_check_choose(
         fit_method = ccxx.queryv1("FIT_METHOD")
         if fit_method and fit_method != b"xy":
             fit_method = lang.getstr("perceptual")
+        elif isinstance(fit_method, bytes):
+            # queryv1() returns bytes; decode so it's consistent with the
+            # localized str the "perceptual" branch above produces.
+            fit_method = fit_method.decode("utf-8")
+        reference_observer = ccxx.queryv1("REFERENCE_OBSERVER")
+        if isinstance(reference_observer, bytes):
+            # queryv1() returns bytes, but observers_ab is keyed by str, so
+            # without decoding this lookup never matches and the "observer"
+            # column always fell back to "unknown"/"not_applicable".
+            reference_observer = reference_observer.decode("utf-8")
         rows_data.append({
             "cgats": cgats_bytes,
             "columns": [
@@ -1081,7 +1091,7 @@ def colorimeter_correction_web_check_choose(
                 ),
                 spectral_res,
                 parent.observers_ab.get(
-                    ccxx.queryv1("REFERENCE_OBSERVER"),
+                    reference_observer,
                     lang.getstr("unknown" if ccxx_type == "CCMX" else "not_applicable"),
                 ),
                 (
@@ -15744,6 +15754,11 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
         dlg.Destroy()
         if result != wx.ID_OK:
             return
+        if isinstance(cgats, str):
+            # upload_colorimeter_correction_handler() passes a str (decoded
+            # from the file), but the regex below requires bytes; normalize
+            # so it doesn't raise TypeError.
+            cgats = cgats.encode("utf-8")
         ccxx = CGATS(cgats)
         # Remove platform-specific/potentially sensitive information
         cgats = re.sub(rb'\n(?:REFERENCE|TARGET)_FILENAME\s+"[^"]+"\n', b"\n", cgats)

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -189,8 +189,16 @@ def test_colorimeter_correction_web_check_choose_observer_column(
     }
     resp = io.BytesIO(json.dumps([entry]).encode("utf-8"))
     expected_label = mainframe.observers_ab["1931_2"]
+    # On GTK3, wx.ListCtrl is DisplayCAL.wx_fixes.ListCtrl, a DataViewListCtrl
+    # shim whose SetStringItem() only creates the real row once every column
+    # has been set. Spy on it (call through to the original) rather than
+    # replacing it outright, otherwise the shim never gets a real row and the
+    # dialog's later GetItem(0) call crashes with a wx assertion error.
+    original_set_string_item = wx.ListCtrl.SetStringItem
     with check_call(BaseInteractiveDialog, "ShowWindowModalBlocking", wx.ID_CANCEL):
-        with check_call(wx.ListCtrl, "SetStringItem", call_count=-1) as calls:
+        with check_call(
+            wx.ListCtrl, "SetStringItem", original_set_string_item, call_count=-1
+        ) as calls:
             colorimeter_correction_web_check_choose(resp, mainframe)
     # SetStringItem(index, col, label) is called on the ListCtrl instance, so
     # the recorded args are (self, index, col, label).

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -1,3 +1,5 @@
+import io
+import json
 import os
 import platform
 import sys
@@ -11,6 +13,7 @@ import wx
 from wx import AppConsole, Button
 
 from DisplayCAL import display_cal, config
+from DisplayCAL import localization as lang
 from DisplayCAL.cgats import CGATS
 from DisplayCAL.config import get_ccxx_testchart, get_icon, getcfg, setcfg
 from DisplayCAL.dev.mocks import check_call, check_call_str
@@ -19,6 +22,7 @@ from DisplayCAL.display_cal import (
     app_up_to_date,
     check_donation,
     colorimeter_correction_check_overwrite,
+    colorimeter_correction_web_check_choose,
     donation_message,
     ExtraArgsFrame,
     GamapFrame,
@@ -155,6 +159,59 @@ def test_colorimeter_correction_check_overwrite(
     finally:
         if os.path.exists(target_path):
             os.remove(target_path)
+
+
+def test_colorimeter_correction_web_check_choose_observer_column(
+    mainframe: MainFrame,
+) -> None:
+    """Regression test: REFERENCE_OBSERVER bytes vs str mismatch.
+
+    ``CGATS.queryv1()`` returns bytes for "REFERENCE_OBSERVER", but
+    ``MainFrame.observers_ab`` (built from ``config.VALID_VALUES["observer"]``)
+    is keyed by str. Looking the bytes value up directly always missed, so the
+    web-check dialog's "observer" column silently fell back to "unknown" for
+    every CCMX correction instead of resolving the real label.
+    """
+    cgats_text = (
+        'CCMX\n\n'
+        'DESCRIPTOR "test"\n'
+        'DISPLAY "LCD Monitor"\n'
+        'REFERENCE_OBSERVER "1931_2"\n'
+        'FIT_METHOD "xy"\n'
+    )
+    entry = {
+        "cgats": cgats_text,
+        "type": "ccmx",
+        "display": "Dell U2413",
+        "manufacturer": "Dell",
+        "reference": "i1 Pro",
+        "description": "i1 DisplayPro, ColorMunki Display",
+    }
+    resp = io.BytesIO(json.dumps([entry]).encode("utf-8"))
+    expected_label = mainframe.observers_ab["1931_2"]
+    with check_call(BaseInteractiveDialog, "ShowWindowModalBlocking", wx.ID_CANCEL):
+        with check_call(wx.ListCtrl, "SetStringItem", call_count=-1) as calls:
+            colorimeter_correction_web_check_choose(resp, mainframe)
+    # SetStringItem(index, col, label) is called on the ListCtrl instance, so
+    # the recorded args are (self, index, col, label).
+    observer_values = [args[3] for args, _kwargs in calls if args[2] == 5]
+    assert observer_values
+    assert expected_label in observer_values
+    assert lang.getstr("unknown") not in observer_values
+
+
+def test_upload_colorimeter_correction_accepts_str_cgats(mainframe: MainFrame) -> None:
+    """Regression test: a str ``cgats`` argument must not raise ``TypeError``.
+
+    ``upload_colorimeter_correction_handler`` reads the file as str
+    (``.decode()``) before calling ``MainFrame.upload_colorimeter_correction``,
+    but that method ran a bytes-pattern regex directly against it, raising
+    ``TypeError`` for every manually-chosen upload file.
+    """
+    cgats_text = 'CCMX\n\nORIGINATOR "Argyll dispcal"\nDISPLAY "LCD Monitor"\n'
+    with check_call(BaseInteractiveDialog, "ShowWindowModalBlocking", wx.ID_OK):
+        with check_call(Worker, "start", call_count=1):
+            mainframe.upload_colorimeter_correction(cgats_text)
 
 
 @pytest.mark.parametrize("file", ("0_16.ti3", "0_16_with_refresh.ti3", "default.ti3"))


### PR DESCRIPTION
## Summary
- `colorimeter_correction_web_check_choose()`: `REFERENCE_OBSERVER`/`FIT_METHOD` come back from `queryv1()` as bytes but were compared/looked up against str data, so the web-check dialog's "observer" column always showed "unknown" for CCMX corrections.
- `MainFrame.upload_colorimeter_correction()`: ran a bytes-pattern regex directly against `cgats`, which crashes with `TypeError` whenever `upload_colorimeter_correction_handler()` passes a str (the manually-chosen-file path); only the create-correction call site (already bytes) avoided it.
- Both found while porting this feature to Qt on the `7-move-the-ui-to-qt` branch; this PR carries the minimal fix over to `develop`.

## Test plan
- [x] Added `test_colorimeter_correction_web_check_choose_observer_column` and `test_upload_colorimeter_correction_accepts_str_cgats` to `tests/test_display_cal.py`; both fail against the unfixed code and pass with the fix.
- [x] Full suite: `pytest -n auto` — 995 passed, 19 skipped.