### PR TITLE
[#794] Fix stale .app suffix in macOS install instructions xattr command

### DIFF
--- a/docs/install_instructions_macos.md
+++ b/docs/install_instructions_macos.md
@@ -17,7 +17,7 @@ want to test the latest code).
 > In **MacOS**, after installing DisplayCAL you need to run the following in Terminal:
 >
 > ```shell
-> xattr -dr com.apple.quarantine /Applications/DisplayCAL.app
+> xattr -dr com.apple.quarantine /Applications/DisplayCAL
 > ```
 
 Install through PyPI or Build From Source


### PR DESCRIPTION
## Summary
- The macOS release DMG packages DisplayCAL as a folder (`/Applications/DisplayCAL`), not a single `DisplayCAL.app` bundle, so the quarantine-removal command in the install docs was pointing at the wrong path.
- Updated `docs/install_instructions_macos.md` to drop the `.app` suffix, matching the already-corrected 3.9.18 release notes.

Fixes #794

## Test plan
- [x] Verified the macOS DMG packaging step in `.github/workflows/release_builds.yml` stages the build output as a folder named `DisplayCAL` (containing multiple `.app` bundles inside), confirming the folder path is correct.