### PR TITLE
[#805] Install prebuilt wxPython wheels from the extras index in DEB/RPM postinstall

### DIFF
--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -423,6 +423,9 @@ jobs:
             --depends "python3 (>= 3.9)" \
             --depends "python3-pip" \
             --depends "python3-venv" \
+            --depends "pkg-config" \
+            --depends "libdbus-1-dev" \
+            --depends "libdbus-glib-1-dev" \
             --after-install /tmp/postinstall.sh \
             --before-remove /tmp/preremove.sh \
             -C /tmp/displaycal-staging \
@@ -449,6 +452,9 @@ jobs:
             --category "Applications/Multimedia" \
             --depends "python3 >= 3.9" \
             --depends "python3-pip" \
+            --depends "pkgconfig" \
+            --depends "dbus-devel" \
+            --depends "dbus-glib-devel" \
             --after-install /tmp/postinstall.sh \
             --before-remove /tmp/preremove.sh \
             -C /tmp/displaycal-staging \

--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -348,6 +348,7 @@ jobs:
           #!/bin/sh
           set -e
           INSTALL_DIR=/opt/displaycal
+          echo "DisplayCAL: setting up virtual environment in ${INSTALL_DIR}/venv ..."
           python3 -m venv "${INSTALL_DIR}/venv"
           PIP="${INSTALL_DIR}/venv/bin/pip"
 
@@ -382,7 +383,13 @@ jobs:
             fi
           fi
 
-          "${PIP}" install --quiet ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
+          if [ -n "${WX_FIND_LINKS}" ]; then
+            echo "DisplayCAL: installing DisplayCAL and its dependencies (using a prebuilt wxPython wheel) ..."
+          else
+            echo "DisplayCAL: installing DisplayCAL and its dependencies (no prebuilt wxPython wheel found for this distro, so it will be built from source, this can take a long time) ..."
+          fi
+          "${PIP}" install --progress-bar=on ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
+          echo "DisplayCAL: install complete."
           if [ -d /etc/udev/rules.d ]; then
             udevadm control --reload-rules 2>/dev/null || true
           fi

--- a/.github/workflows/nightly_builds.yml
+++ b/.github/workflows/nightly_builds.yml
@@ -349,7 +349,40 @@ jobs:
           set -e
           INSTALL_DIR=/opt/displaycal
           python3 -m venv "${INSTALL_DIR}/venv"
-          "${INSTALL_DIR}/venv/bin/pip" install --quiet "${INSTALL_DIR}"/displaycal-*.whl
+          PIP="${INSTALL_DIR}/venv/bin/pip"
+
+          # Prefer a prebuilt wxPython wheel from the wxPython extras index for
+          # the running distro, so pip doesn't have to build wxWidgets/wxPython
+          # from source. The extras index only covers a fixed set of distro
+          # releases, so pick the newest one that is <= the running release
+          # (a wheel built against an older glibc/libstdc++ still runs fine on
+          # a newer system). Falls back to a source build via PyPI if nothing
+          # applies.
+          WX_FIND_LINKS=""
+          if [ -r /etc/os-release ]; then
+            . /etc/os-release
+            case "${ID}" in
+              ubuntu) WX_KNOWN="14.04 16.04 18.04 20.04 22.04 24.04" ;;
+              debian) WX_KNOWN="8 9 10 11" ;;
+              fedora) WX_KNOWN="23 24 26 27 28 29 30 31 35 36 37 38" ;;
+              centos) WX_KNOWN="7 8" ;;
+              rocky) WX_KNOWN="8 9" ;;
+              *) WX_KNOWN="" ;;
+            esac
+
+            WX_VERSION=""
+            for known in ${WX_KNOWN}; do
+              if [ "$(printf '%s\n%s\n' "${known}" "${VERSION_ID}" | sort -V | head -n1)" = "${known}" ]; then
+                WX_VERSION="${known}"
+              fi
+            done
+
+            if [ -n "${WX_VERSION}" ]; then
+              WX_FIND_LINKS="-f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${ID}-${WX_VERSION}/"
+            fi
+          fi
+
+          "${PIP}" install --quiet ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
           if [ -d /etc/udev/rules.d ]; then
             udevadm control --reload-rules 2>/dev/null || true
           fi

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -354,6 +354,9 @@ jobs:
             --depends "python3 (>= 3.9)" \
             --depends "python3-pip" \
             --depends "python3-venv" \
+            --depends "pkg-config" \
+            --depends "libdbus-1-dev" \
+            --depends "libdbus-glib-1-dev" \
             --after-install /tmp/postinstall.sh \
             --before-remove /tmp/preremove.sh \
             -C /tmp/displaycal-staging \
@@ -379,6 +382,9 @@ jobs:
             --category "Applications/Multimedia" \
             --depends "python3 >= 3.9" \
             --depends "python3-pip" \
+            --depends "pkgconfig" \
+            --depends "dbus-devel" \
+            --depends "dbus-glib-devel" \
             --after-install /tmp/postinstall.sh \
             --before-remove /tmp/preremove.sh \
             -C /tmp/displaycal-staging \

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -279,6 +279,7 @@ jobs:
           #!/bin/sh
           set -e
           INSTALL_DIR=/opt/displaycal
+          echo "DisplayCAL: setting up virtual environment in ${INSTALL_DIR}/venv ..."
           python3 -m venv "${INSTALL_DIR}/venv"
           PIP="${INSTALL_DIR}/venv/bin/pip"
 
@@ -313,7 +314,13 @@ jobs:
             fi
           fi
 
-          "${PIP}" install --quiet ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
+          if [ -n "${WX_FIND_LINKS}" ]; then
+            echo "DisplayCAL: installing DisplayCAL and its dependencies (using a prebuilt wxPython wheel) ..."
+          else
+            echo "DisplayCAL: installing DisplayCAL and its dependencies (no prebuilt wxPython wheel found for this distro, so it will be built from source, this can take a long time) ..."
+          fi
+          "${PIP}" install --progress-bar=on ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
+          echo "DisplayCAL: install complete."
           if [ -d /etc/udev/rules.d ]; then
             udevadm control --reload-rules 2>/dev/null || true
           fi

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -280,7 +280,40 @@ jobs:
           set -e
           INSTALL_DIR=/opt/displaycal
           python3 -m venv "${INSTALL_DIR}/venv"
-          "${INSTALL_DIR}/venv/bin/pip" install --quiet "${INSTALL_DIR}"/displaycal-*.whl
+          PIP="${INSTALL_DIR}/venv/bin/pip"
+
+          # Prefer a prebuilt wxPython wheel from the wxPython extras index for
+          # the running distro, so pip doesn't have to build wxWidgets/wxPython
+          # from source. The extras index only covers a fixed set of distro
+          # releases, so pick the newest one that is <= the running release
+          # (a wheel built against an older glibc/libstdc++ still runs fine on
+          # a newer system). Falls back to a source build via PyPI if nothing
+          # applies.
+          WX_FIND_LINKS=""
+          if [ -r /etc/os-release ]; then
+            . /etc/os-release
+            case "${ID}" in
+              ubuntu) WX_KNOWN="14.04 16.04 18.04 20.04 22.04 24.04" ;;
+              debian) WX_KNOWN="8 9 10 11" ;;
+              fedora) WX_KNOWN="23 24 26 27 28 29 30 31 35 36 37 38" ;;
+              centos) WX_KNOWN="7 8" ;;
+              rocky) WX_KNOWN="8 9" ;;
+              *) WX_KNOWN="" ;;
+            esac
+
+            WX_VERSION=""
+            for known in ${WX_KNOWN}; do
+              if [ "$(printf '%s\n%s\n' "${known}" "${VERSION_ID}" | sort -V | head -n1)" = "${known}" ]; then
+                WX_VERSION="${known}"
+              fi
+            done
+
+            if [ -n "${WX_VERSION}" ]; then
+              WX_FIND_LINKS="-f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${ID}-${WX_VERSION}/"
+            fi
+          fi
+
+          "${PIP}" install --quiet ${WX_FIND_LINKS} "${INSTALL_DIR}"/displaycal-*.whl
           if [ -d /etc/udev/rules.d ]; then
             udevadm control --reload-rules 2>/dev/null || true
           fi


### PR DESCRIPTION
## Summary

- The DEB/RPM postinstall script (`.github/workflows/release_builds.yml` / `nightly_builds.yml`) now points `pip` at the [wxPython extras index](https://extras.wxpython.org/wxPython4/extras/linux/gtk3/) for the running distro before installing the DisplayCAL wheel, so it gets a prebuilt wxPython wheel instead of building wxWidgets/wxPython from source.
- The extras index only publishes a fixed set of distro releases, so the script picks the newest one that is `<=` the running release (a wheel built against an older glibc/libstdc++ still runs fine on a newer system) — this is what makes newer releases like Ubuntu 26.04 resolve to the `ubuntu-24.04` wheels instead of failing outright.
- Falls back to a normal source build via PyPI if nothing applies (unknown distro, or a release older than anything published).

## Test plan

Validated the resolution + install logic in real Docker containers (not just read the code):
- [x] Ubuntu 22.04 (real): resolves to `ubuntu-22.04`, installs prebuilt `wxpython-4.2.5-cp310-cp310-linux_x86_64.whl`
- [x] Ubuntu 26.04 (simulated via `/etc/os-release` override, since it isn't released yet): correctly falls back to and installs the `ubuntu-24.04` wheel
- [x] Ubuntu 12.04 (older than anything published): correctly skips find-links and falls back to a normal PyPI source build
- [x] Fedora 44 (real, current `fedora:latest`): correctly resolves to `fedora-38` (the newest published Fedora release), but that directory only has wheels up to cp311 — Fedora 44 ships Python 3.14, so no matching prebuilt wheel exists there yet and it falls back to a source build, same as before this change for that specific distro/Python combination
- [x] Both workflow YAML files parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)