### PR TITLE
[#811] Fix bytes-vs-str "CTI3" comparisons and TypeError in measurement/profile handlers

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -10401,9 +10401,9 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
         # Determine if we should use planckian locus for assumed target wp
         # Detection will only work for profiles created by DisplayCAL
         planckian = False
-        if (profile.tags.get("CIED", "") or profile.tags.get("targ", ""))[
+        if (profile.tags.get("CIED", b"") or profile.tags.get("targ", b""))[
             0:4
-        ] == "CTI3":
+        ] == b"CTI3":
             options_dispcal = get_options_from_profile(profile)[0]
             for option in options_dispcal:
                 if option.startswith("T"):
@@ -14786,10 +14786,10 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                             instrument = "EDID"
                         else:
                             targ = profile.tags.get(
-                                "CIED", profile.tags.get("targ", "")
+                                "CIED", profile.tags.get("targ", b"")
                             )
                             instrument = None
-                            if targ[0:4] == "CTI3":
+                            if targ[0:4] == b"CTI3":
                                 targ = CGATS(targ)
                                 instrument = targ.queryv1("TARGET_INSTRUMENT")
                             if not instrument:
@@ -17289,15 +17289,17 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     Error(lang.getstr("profile.invalid") + "\n" + path), self
                 )
                 return
-            if (profile.tags.get("CIED", "") or profile.tags.get("targ", ""))[
+            if (profile.tags.get("CIED", b"") or profile.tags.get("targ", b""))[
                 0:4
-            ] != "CTI3":
+            ] != b"CTI3":
                 show_result_dialog(
                     Error(lang.getstr("profile.no_embedded_ti3") + "\n" + path),
                     self,
                 )
                 return
-            ti3 = BytesIO(profile.tags.get("CIED", "") or profile.tags.get("targ", ""))
+            ti3 = BytesIO(
+                profile.tags.get("CIED", b"") or profile.tags.get("targ", b"")
+            )
         else:
             profile = None
             try:
@@ -17330,7 +17332,9 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 if isinstance(tmp_working_dir, Exception):
                     show_result_dialog(tmp_working_dir, self)
                     return
-                profile.tags.targ = TextType(b"text\0\0\0\0" + ti3 + b"\0", b"targ")
+                profile.tags.targ = TextType(
+                    b"text\0\0\0\0" + bytes(ti3) + b"\0", b"targ"
+                )
                 profile.tags.DevD = profile.tags.CIED = profile.tags.targ
                 tmp_path = os.path.join(tmp_working_dir, os.path.basename(path))
                 profile.write(tmp_path)
@@ -17957,9 +17961,9 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                         bitmap=get_icon(32, "dialog-error"),
                     )
                     return
-                if (profile.tags.get("CIED", "") or profile.tags.get("targ", ""))[
+                if (profile.tags.get("CIED", b"") or profile.tags.get("targ", b""))[
                     0:4
-                ] != "CTI3":
+                ] != b"CTI3":
                     InfoDialog(
                         self,
                         msg=f"{lang.getstr('profile.no_embedded_ti3')}\n{path_}",
@@ -17968,7 +17972,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                     )
                     return
                 with BytesIO(
-                    profile.tags.get("CIED", "") or profile.tags.get("targ", "")
+                    profile.tags.get("CIED", b"") or profile.tags.get("targ", b"")
                 ) as ti3:
                     ti3_lines = [line.strip() for line in ti3]
                 # Preserve custom tags

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -37,10 +37,11 @@ from DisplayCAL.display_cal import (
     StartupFrame,
     webbrowser_open,
 )
+from DisplayCAL.icc_profile import ICCProfile
 from DisplayCAL.util_str import universal_newlines
 from DisplayCAL.util_list import intlist
 from DisplayCAL.worker import Worker, check_ti3
-from DisplayCAL.wx_windows import ConfirmDialog, BaseInteractiveDialog
+from DisplayCAL.wx_windows import ConfirmDialog, BaseInteractiveDialog, InfoDialog
 
 
 @pytest.fixture(scope="session", name="app", autouse=True)
@@ -513,3 +514,84 @@ def test_create_profile_name_crc32_without_edid(
     monkeypatch.setattr(mainframe.worker, "get_display_edid", lambda: {})
     mainframe.profile_name_textctrl.SetValue("name-%crc32-suffix")
     assert mainframe.create_profile_name() == "name-suffix"
+
+
+def test_create_profile_handler_accepts_valid_embedded_cti3(
+    data_files, mainframe: MainFrame
+) -> None:
+    """Regression test for issue #811: bytes-vs-str "CTI3" comparison bug.
+
+    ``(profile.tags.get("CIED", "") or profile.tags.get("targ", ""))[0:4] !=
+    "CTI3"`` compared the ``bytes`` slice of an embedded ``Text`` tag against
+    the ``str`` literal ``"CTI3"``, which is never equal in Python 3, so the
+    "no embedded ti3" error fired for every ICC profile regardless of its
+    actual content. Uses a real profile with a valid embedded CTI3 chart and
+    asserts the ``profile.no_embedded_ti3`` ``InfoDialog`` is never shown.
+    """
+    icc_path = str(
+        data_files[
+            "UP2516D #1 2022-03-20 02-08 D6500 2.2 F-S XYZLUT+MTX.icc"
+        ].absolute()
+    )
+    with check_call(InfoDialog, "ShowModal", wx.ID_OK, call_count=0):
+        with check_call(wx.FileDialog, "ShowModal", wx.ID_CANCEL, call_count=1):
+            mainframe.create_profile_handler(None, icc_path, False)
+
+
+def test_measurement_file_check_handler_regenerates_profile_without_typeerror(
+    data_files, mainframe: MainFrame, monkeypatch
+) -> None:
+    """Regression test for issue #811.
+
+    Covers two bugs in ``measurement_file_check_handler()``'s profile
+    regeneration branch:
+
+    1. The bytes-vs-str "CTI3" comparison (same bug as
+       ``test_create_profile_handler_accepts_valid_embedded_cti3`` above, but
+       at this method's own call site): asserted via the
+       ``profile.no_embedded_ti3`` ``InfoDialog`` never being shown.
+    2. ``profile.tags.targ = TextType(b"text\\0\\0\\0\\0" + ti3 + b"\\0", ...)``
+       concatenated ``bytes`` with a ``CGATS`` instance (``ti3`` is reassigned
+       to ``CGATS(ti3)`` earlier in the method), raising ``TypeError`` on
+       every profile regeneration. Fixed by using ``bytes(ti3)``.
+    """
+    icc_path = str(
+        data_files[
+            "UP2516D #1 2022-03-20 02-08 D6500 2.2 F-S XYZLUT+MTX.icc"
+        ].absolute()
+    )
+
+    def _fake_confirm(self, ti3=None, force=False, parent=None):
+        # Skip the sanity-check dialog itself (covered elsewhere); pretend
+        # the user removed a suspicious patch so the regeneration branch runs.
+        ti3.modified = True
+        return True
+
+    # wx.FileDialog is DisplayCAL.wx_fixes.FileDialog, whose GetPath()/etc.
+    # are proxied to an inner ``self.filedialog`` via __getattr__ rather than
+    # being real class attributes, so stub GetPath as an instance attribute
+    # (which __getattr__ never intercepts) right after construction.
+    original_filedialog_init = wx.FileDialog.__init__
+
+    def _fake_filedialog_init(self, *args, **kwargs):
+        original_filedialog_init(self, *args, **kwargs)
+        self.GetPath = lambda: icc_path
+
+    monkeypatch.setattr(wx.FileDialog, "__init__", _fake_filedialog_init)
+    monkeypatch.setattr(wx.FileDialog, "ShowModal", lambda self: wx.ID_OK)
+    monkeypatch.setattr(
+        MainFrame, "measurement_file_check_confirm", _fake_confirm
+    )
+    monkeypatch.setattr(ConfirmDialog, "ShowModal", lambda self: wx.ID_OK)
+    create_profile_calls = []
+    monkeypatch.setattr(
+        MainFrame,
+        "create_profile_handler",
+        lambda self, event, path, skip_ti3_check: create_profile_calls.append(path),
+    )
+    with check_call(InfoDialog, "ShowModal", wx.ID_OK, call_count=0):
+        mainframe.measurement_file_check_handler(None)
+    assert len(create_profile_calls) == 1
+    assert create_profile_calls[0].endswith(
+        os.path.basename(icc_path)
+    )


### PR DESCRIPTION
## Summary
- Fixes four sites in `DisplayCAL/display_cal.py` where a `bytes` slice of an embedded `CIED`/`targ` `Text` tag was compared against the `str` literal `"CTI3"`, which is never equal in Python 3: `measurement_report_consumer()` (planckian-locus detection), `create_colorimeter_correction_handler()` (`TARGET_INSTRUMENT` lookup), `measurement_file_check_handler()` and `create_profile_handler()` (embedded-CTI3-chart check). All four now compare against `b"CTI3"` with `b""` fallback defaults.
- Fixes a `TypeError: can't concat CGATS to bytes` crash in `measurement_file_check_handler()`'s profile-regeneration branch, where `ti3` had already been reassigned to a `CGATS` instance before being concatenated with `bytes`. Uses `bytes(ti3)` instead.
- Adds regression tests covering the `create_profile_handler()` CTI3 check and the full `measurement_file_check_handler()` regeneration flow (which also exercises the `TypeError` fix), using a real ICC profile fixture with an embedded CTI3 chart.

Closes #811

## Test plan
- [x] `pytest tests/test_display_cal.py` (65 passed, 1 pre-existing skip)
- [x] Full suite: `pytest tests/ -n auto` (997 passed, 19 skipped)
- [x] Verified both new tests fail against the pre-fix code, including reproducing the exact `TypeError: can't concat CGATS to bytes` crash