### PR TITLE
Reduce pytest.yml CI matrix to latest wxPython per Python/OS

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,83 +15,24 @@ env:
 
 jobs:
   linux:
-    name: Linux + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: Linux + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
     env:
       DISPLAY: :0
       DEBIAN_FRONTEND: noninteractive
+      # Only test the latest available wxPython release per Python version.
+      # The package name is "wxpython" (lowercase) for 4.2.3 and up.
+      WX_VERSION: "4.2.5"
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # tedious but easier... As we do not have all wxPython version for
-          # all other Python versions, and more so the wxPython package name
-          # changes from "wxPython" to "wxpython" for 4.2.3 and up...
-
-          # Python 3.10
-          - python-version: "3.10"
-            wx-version: "4.2.2"
-            wx_name: "wxPython"
-          - python-version: "3.10"
-            wx-version: "4.2.3"
-            wx_name: "wxpython"
-          - python-version: "3.10"
-            wx-version: "4.2.4"
-            wx_name: "wxpython"
-          - python-version: "3.10"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-
-          # Python 3.11
-          - python-version: "3.11"
-            wx-version: "4.2.2"
-            wx_name: "wxPython"
-          - python-version: "3.11"
-            wx-version: "4.2.3"
-            wx_name: "wxpython"
-          - python-version: "3.11"
-            wx-version: "4.2.4"
-            wx_name: "wxpython"
-          - python-version: "3.11"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-
-          # Python 3.12
-          - python-version: "3.12"
-            wx-version: "4.2.2"
-            wx_name: "wxPython"
-          - python-version: "3.12"
-            wx-version: "4.2.3"
-            wx_name: "wxpython"
-          - python-version: "3.12"
-            wx-version: "4.2.4"
-            wx_name: "wxpython"
-          - python-version: "3.12"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-
-          # Python 3.13
-          - python-version: "3.13"
-            wx-version: "4.2.2"
-            wx_name: "wxPython"
-          - python-version: "3.13"
-            wx-version: "4.2.3"
-            wx_name: "wxpython"
-          - python-version: "3.13"
-            wx-version: "4.2.4"
-            wx_name: "wxpython"
-          - python-version: "3.13"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-
-          # Python 3.14
-          - python-version: "3.14"
-            wx-version: "4.2.4"
-            wx_name: "wxpython"
-          - python-version: "3.14"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
     - uses: actions/checkout@v5
@@ -151,12 +92,11 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
         py_version="${{ matrix.python-version }}"
         py_version="${py_version//./}"
-        wx_name="${{ matrix.wx_name}}"
-        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/${wx_name}-${{ matrix.wx-version }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
+        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxpython-${{ env.WX_VERSION }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
 
     - name: Install Python dependencies
       run: |
@@ -179,13 +119,16 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-linux
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-linux
         path: htmlcov
         retention-days: 10
 
   windows:
-    name: Windows + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: Windows + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
     runs-on: windows-latest
+    env:
+      # Only test the latest available wxPython release per Python version.
+      WX_VERSION: "4.2.5"
 
     strategy:
       fail-fast: false
@@ -193,11 +136,6 @@ jobs:
         python-version:
           - "3.10"
           - "3.11"
-        wx-version:
-          - "4.2.2"
-          - "4.2.3"
-          - "4.2.4"
-          - "4.2.5"
 
     steps:
     - uses: actions/checkout@v5
@@ -229,9 +167,9 @@ jobs:
         $ScriptsPath = python -c "import sysconfig,os; print(sysconfig.get_path('scripts'))"
         Add-Content $env:GITHUB_PATH $ScriptsPath
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ matrix.wx-version }}
+        uv pip install --system wxPython==${{ env.WX_VERSION }}
 
     - name: Install Python dependencies
       run: |
@@ -258,35 +196,25 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-windows
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-windows
         path: htmlcov
         retention-days: 10
 
   macos:
-    name: macOS + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: macOS + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
     runs-on: macos-14
+    env:
+      # Only test the latest available wxPython release per Python version.
+      WX_VERSION: "4.2.5"
 
     strategy:
       fail-fast: false
       matrix:
-        # for now we just care about the Python version.
-        # After the workflow stabilizes we introduce different wxPython versions
-        # too...
         python-version:
           - "3.11"
           - "3.12"
           - "3.13"
           - "3.14"
-        wx-version:
-          - "4.2.2"
-          - "4.2.3"
-          - "4.2.4"
-          - "4.2.5"
-        exclude:
-          - wx-version: "4.2.2"
-            python-version: "3.14"
-          - wx-version: "4.2.3"
-            python-version: "3.14"
 
     steps:
     - uses: actions/checkout@v5
@@ -315,9 +243,9 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ matrix.wx-version }}
+        uv pip install --system wxPython==${{ env.WX_VERSION }}
 
     - name: Install Python dependencies
       run: |
@@ -339,6 +267,6 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-macos
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-macos
         path: htmlcov
         retention-days: 10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,10 +12,14 @@ on:
 env:
   ARGYLL_VERSION: "3.5.0"
   ARGYLL_REPO: "https://github.com/eoyilmaz/argyllcms-binaries/releases/download"
+  # Pinned wxPython release, available as a pre-built wheel for every
+  # supported Python version. Note: the "env" context isn't available in
+  # `jobs.<job_id>.name`, so this can't be interpolated into job names.
+  WX_VERSION: "4.2.5"
 
 jobs:
   linux:
-    name: Linux + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: Linux + Python ${{ matrix.python-version }} + wxPython 4.2.5
     env:
       DISPLAY: :0
       DEBIAN_FRONTEND: noninteractive
@@ -24,26 +28,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Only the highest wxPython release available as a pre-built wheel
-          # per Python version, instead of the full 4.2.2-4.2.5 cross
-          # product. The wxPython package name is "wxpython" (lowercase)
-          # for 4.2.3 and up.
-          - python-version: "3.10"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-          - python-version: "3.11"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-          - python-version: "3.12"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-          - python-version: "3.13"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
-          - python-version: "3.14"
-            wx-version: "4.2.5"
-            wx_name: "wxpython"
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
     - uses: actions/checkout@v5
@@ -103,12 +93,11 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
         py_version="${{ matrix.python-version }}"
         py_version="${py_version//./}"
-        wx_name="${{ matrix.wx_name}}"
-        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/${wx_name}-${{ matrix.wx-version }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
+        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxpython-${{ env.WX_VERSION }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
 
     - name: Install Python dependencies
       run: |
@@ -131,24 +120,20 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-linux
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-linux
         path: htmlcov
         retention-days: 10
 
   windows:
-    name: Windows + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: Windows + Python ${{ matrix.python-version }} + wxPython 4.2.5
     runs-on: windows-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Only the highest wxPython release available as a pre-built wheel
-          # per Python version.
-          - python-version: "3.10"
-            wx-version: "4.2.5"
-          - python-version: "3.11"
-            wx-version: "4.2.5"
+        python-version:
+          - "3.10"
+          - "3.11"
 
     steps:
     - uses: actions/checkout@v5
@@ -180,9 +165,9 @@ jobs:
         $ScriptsPath = python -c "import sysconfig,os; print(sysconfig.get_path('scripts'))"
         Add-Content $env:GITHUB_PATH $ScriptsPath
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ matrix.wx-version }}
+        uv pip install --system wxPython==${{ env.WX_VERSION }}
 
     - name: Install Python dependencies
       run: |
@@ -209,28 +194,22 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-windows
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-windows
         path: htmlcov
         retention-days: 10
 
   macos:
-    name: macOS + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
+    name: macOS + Python ${{ matrix.python-version }} + wxPython 4.2.5
     runs-on: macos-14
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Only the highest wxPython release available as a pre-built wheel
-          # per Python version.
-          - python-version: "3.11"
-            wx-version: "4.2.5"
-          - python-version: "3.12"
-            wx-version: "4.2.5"
-          - python-version: "3.13"
-            wx-version: "4.2.5"
-          - python-version: "3.14"
-            wx-version: "4.2.5"
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
     - uses: actions/checkout@v5
@@ -259,9 +238,9 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ matrix.wx-version }}
+    - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ matrix.wx-version }}
+        uv pip install --system wxPython==${{ env.WX_VERSION }}
 
     - name: Install Python dependencies
       run: |
@@ -283,6 +262,6 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-macos
+        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-macos
         path: htmlcov
         retention-days: 10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,24 +15,35 @@ env:
 
 jobs:
   linux:
-    name: Linux + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
+    name: Linux + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
     env:
       DISPLAY: :0
       DEBIAN_FRONTEND: noninteractive
-      # Only test the latest available wxPython release per Python version.
-      # The package name is "wxpython" (lowercase) for 4.2.3 and up.
-      WX_VERSION: "4.2.5"
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
+        include:
+          # Only the highest wxPython release available as a pre-built wheel
+          # per Python version, instead of the full 4.2.2-4.2.5 cross
+          # product. The wxPython package name is "wxpython" (lowercase)
+          # for 4.2.3 and up.
+          - python-version: "3.10"
+            wx-version: "4.2.5"
+            wx_name: "wxpython"
+          - python-version: "3.11"
+            wx-version: "4.2.5"
+            wx_name: "wxpython"
+          - python-version: "3.12"
+            wx-version: "4.2.5"
+            wx_name: "wxpython"
+          - python-version: "3.13"
+            wx-version: "4.2.5"
+            wx_name: "wxpython"
+          - python-version: "3.14"
+            wx-version: "4.2.5"
+            wx_name: "wxpython"
 
     steps:
     - uses: actions/checkout@v5
@@ -92,11 +103,12 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ env.WX_VERSION }}
+    - name: Install wxPython ${{ matrix.wx-version }}
       run: |
         py_version="${{ matrix.python-version }}"
         py_version="${py_version//./}"
-        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxpython-${{ env.WX_VERSION }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
+        wx_name="${{ matrix.wx_name}}"
+        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/${wx_name}-${{ matrix.wx-version }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
 
     - name: Install Python dependencies
       run: |
@@ -119,23 +131,24 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-linux
+        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-linux
         path: htmlcov
         retention-days: 10
 
   windows:
-    name: Windows + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
+    name: Windows + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
     runs-on: windows-latest
-    env:
-      # Only test the latest available wxPython release per Python version.
-      WX_VERSION: "4.2.5"
 
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
+        include:
+          # Only the highest wxPython release available as a pre-built wheel
+          # per Python version.
+          - python-version: "3.10"
+            wx-version: "4.2.5"
+          - python-version: "3.11"
+            wx-version: "4.2.5"
 
     steps:
     - uses: actions/checkout@v5
@@ -167,9 +180,9 @@ jobs:
         $ScriptsPath = python -c "import sysconfig,os; print(sysconfig.get_path('scripts'))"
         Add-Content $env:GITHUB_PATH $ScriptsPath
 
-    - name: Install wxPython ${{ env.WX_VERSION }}
+    - name: Install wxPython ${{ matrix.wx-version }}
       run: |
-        uv pip install --system wxPython==${{ env.WX_VERSION }}
+        uv pip install --system wxPython==${{ matrix.wx-version }}
 
     - name: Install Python dependencies
       run: |
@@ -196,25 +209,28 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-windows
+        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-windows
         path: htmlcov
         retention-days: 10
 
   macos:
-    name: macOS + Python ${{ matrix.python-version }} + wxPython ${{ env.WX_VERSION }}
+    name: macOS + Python ${{ matrix.python-version }} + wxPython ${{ matrix.wx-version }}
     runs-on: macos-14
-    env:
-      # Only test the latest available wxPython release per Python version.
-      WX_VERSION: "4.2.5"
 
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
+        include:
+          # Only the highest wxPython release available as a pre-built wheel
+          # per Python version.
+          - python-version: "3.11"
+            wx-version: "4.2.5"
+          - python-version: "3.12"
+            wx-version: "4.2.5"
+          - python-version: "3.13"
+            wx-version: "4.2.5"
+          - python-version: "3.14"
+            wx-version: "4.2.5"
 
     steps:
     - uses: actions/checkout@v5
@@ -243,9 +259,9 @@ jobs:
     - name: Install wheel helper
       run: uv pip install --system wheel
 
-    - name: Install wxPython ${{ env.WX_VERSION }}
+    - name: Install wxPython ${{ matrix.wx-version }}
       run: |
-        uv pip install --system wxPython==${{ env.WX_VERSION }}
+        uv pip install --system wxPython==${{ matrix.wx-version }}
 
     - name: Install Python dependencies
       run: |
@@ -267,6 +283,6 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage-report-${{ matrix.python-version }}-${{ env.WX_VERSION }}-macos
+        name: code-coverage-report-${{ matrix.python-version }}-${{ matrix.wx-version }}-macos
         path: htmlcov
         retention-days: 10

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,13 +13,12 @@ env:
   ARGYLL_VERSION: "3.5.0"
   ARGYLL_REPO: "https://github.com/eoyilmaz/argyllcms-binaries/releases/download"
   # Pinned wxPython release, available as a pre-built wheel for every
-  # supported Python version. Note: the "env" context isn't available in
-  # `jobs.<job_id>.name`, so this can't be interpolated into job names.
+  # supported Python version.
   WX_VERSION: "4.2.5"
 
 jobs:
   linux:
-    name: Linux + Python ${{ matrix.python-version }} + wxPython 4.2.5
+    name: Linux + Python ${{ matrix.python-version }}
     env:
       DISPLAY: :0
       DEBIAN_FRONTEND: noninteractive
@@ -125,7 +124,7 @@ jobs:
         retention-days: 10
 
   windows:
-    name: Windows + Python ${{ matrix.python-version }} + wxPython 4.2.5
+    name: Windows + Python ${{ matrix.python-version }}
     runs-on: windows-latest
 
     strategy:
@@ -199,7 +198,7 @@ jobs:
         retention-days: 10
 
   macos:
-    name: macOS + Python ${{ matrix.python-version }} + wxPython 4.2.5
+    name: macOS + Python ${{ matrix.python-version }}
     runs-on: macos-14
 
     strategy:


### PR DESCRIPTION
## Summary
- Test only the latest available wxPython release (4.2.5) per (Python version, OS) combination instead of the full cross product of wxPython patch releases.
- Cuts the CI matrix from 40 jobs to 11 (Linux 5, Windows 2, macOS 4).

## Why
wxPython patch releases in the 4.2.x series are almost entirely bugfixes with a stable API, so testing all four wx versions against every Python version mostly guards against wxWidgets/wxPython's own regressions rather than ours, while multiplying CI time and exposure to flaky external wheel downloads from `extras.wxpython.org`.

## Follow-up (out of scope here)
A full cross-version matrix could still run on a schedule (e.g. weekly, similar to `nightly_builds.yml`) to catch regressions on older wx versions without paying the cost on every PR.

Closes #813

## Test plan
- [x] CI passes on all 11 jobs (Linux/Windows/macOS x supported Python versions) with wxPython 4.2.5