### PR TITLE
Decode bytes profile attributes in profile.unsupported dialog (#815)

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -9130,7 +9130,10 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 self,
                 msg=lang.getstr(
                     "profile.unsupported",
-                    (profile.profileClass, profile.colorSpace),
+                    (
+                        profile.profileClass.decode("utf-8"),
+                        profile.colorSpace.decode("utf-8"),
+                    ),
                 )
                 + "\n"
                 + profile_path,
@@ -9630,7 +9633,10 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 parent,
                 msg=lang.getstr(
                     "profile.unsupported",
-                    (profile.profileClass, profile.colorSpace),
+                    (
+                        profile.profileClass.decode("utf-8"),
+                        profile.colorSpace.decode("utf-8"),
+                    ),
                 )
                 + "\n"
                 + path,
@@ -17820,10 +17826,11 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
         ) or ("A2B1" in profile.tags and not isinstance(profile.tags.A2B1, LUT16Type)):
             result = Error(lang.getstr("profile.required_tags_missing", "LUT16Type"))
         elif profile.connectionColorSpace not in (b"XYZ", b"Lab"):
+            connection_color_space = profile.connectionColorSpace.decode("utf-8")
             result = Error(
                 lang.getstr(
                     "profile.unsupported",
-                    (profile.connectionColorSpace, profile.connectionColorSpace),
+                    (connection_color_space, connection_color_space),
                 )
             )
         else:

--- a/DisplayCAL/worker.py
+++ b/DisplayCAL/worker.py
@@ -2972,7 +2972,10 @@ class Worker(WorkerBase):
                         + ": "
                         + lang.getstr(
                             "profile.unsupported",
-                            (lang.getstr("unknown"), profile1.colorSpace),
+                            (
+                                lang.getstr("unknown"),
+                                profile1.colorSpace.decode("utf-8"),
+                            ),
                         )
                     )
                 rgb_space[0] = 1.0  # Set gamma to 1.0 (not actually used)
@@ -4428,7 +4431,10 @@ END_DATA
                 raise NotImplementedError(
                     lang.getstr(
                         "profile.unsupported",
-                        (profile.profileClass, profile.colorSpace),
+                        (
+                            profile.profileClass.decode("utf-8"),
+                            profile.colorSpace.decode("utf-8"),
+                        ),
                     )
                 )
             if profile_in.profileClass == b"link":
@@ -8004,10 +8010,11 @@ BEGIN_DATA
         """
         # Lab cLUT is currently not implemented and should NOT be used!
         if profile.connectionColorSpace != b"XYZ":
+            connection_color_space = profile.connectionColorSpace.decode("utf-8")
             raise Error(
                 lang.getstr(
                     "profile.unsupported",
-                    (profile.connectionColorSpace, profile.connectionColorSpace),
+                    (connection_color_space, connection_color_space),
                 )
             )
 
@@ -14878,7 +14885,10 @@ BEGIN_DATA
                     Error(
                         lang.getstr(
                             "profile.unsupported",
-                            (profile.profileClass, profile.colorSpace),
+                            (
+                                profile.profileClass.decode("utf-8"),
+                                profile.colorSpace.decode("utf-8"),
+                            ),
                         )
                         + "\n"
                         + profile_path

--- a/DisplayCAL/wx_lut_3d_frame.py
+++ b/DisplayCAL/wx_lut_3d_frame.py
@@ -2055,7 +2055,10 @@ class LUT3DFrame(BaseFrame, LUT3DMixin):
                         Error(
                             lang.getstr(
                                 "profile.unsupported",
-                                (profile.profileClass, profile.colorSpace),
+                                (
+                                    profile.profileClass.decode("utf-8"),
+                                    profile.colorSpace.decode("utf-8"),
+                                ),
                             )
                         ),
                         parent=self,

--- a/DisplayCAL/wx_lut_viewer.py
+++ b/DisplayCAL/wx_lut_viewer.py
@@ -1516,7 +1516,10 @@ class LUTFrame(BaseFrame):
                 Error(
                     lang.getstr(
                         "profile.unsupported",
-                        (profile.profileClass, unsupported_colorspace),
+                        (
+                            profile.profileClass.decode("utf-8"),
+                            unsupported_colorspace.decode("utf-8"),
+                        ),
                     )
                 )
             )

--- a/DisplayCAL/wx_profile_info.py
+++ b/DisplayCAL/wx_profile_info.py
@@ -559,7 +559,10 @@ class GamutCanvas(LUTCanvas):
                         Error(
                             lang.getstr(
                                 "profile.unsupported",
-                                (profile.profileClass, profile.colorSpace),
+                                (
+                                    profile.profileClass.decode("utf-8"),
+                                    profile.colorSpace.decode("utf-8"),
+                                ),
                             )
                         )
                     )

--- a/DisplayCAL/wx_report_frame.py
+++ b/DisplayCAL/wx_report_frame.py
@@ -644,7 +644,10 @@ class ReportFrame(BaseFrame):
                     NotImplementedError(
                         lang.getstr(
                             "profile.unsupported",
-                            (profile.profileClass, profile.colorSpace),
+                            (
+                                profile.profileClass.decode("utf-8"),
+                                profile.colorSpace.decode("utf-8"),
+                            ),
                         )
                     ),
                     parent=self,

--- a/DisplayCAL/wx_synth_icc_frame.py
+++ b/DisplayCAL/wx_synth_icc_frame.py
@@ -513,7 +513,10 @@ class SynthICCFrame(BaseFrame, LUT3DMixin):
                     Error(
                         lang.getstr(
                             "profile.unsupported",
-                            (profile.profileClass, profile.colorSpace),
+                            (
+                                profile.profileClass.decode("utf-8"),
+                                profile.colorSpace.decode("utf-8"),
+                            ),
                         )
                     ),
                     self,


### PR DESCRIPTION
## Summary
- `profile.profileClass`, `profile.colorSpace`, and `profile.connectionColorSpace` are `bytes` parsed from the ICC header. Several `"profile.unsupported"` dialog/error call sites passed them straight into `lang.getstr()`'s `%s` formatting without decoding, producing garbled text like `Unsupported profile type (b'mntr') and/or colorspace (b'RGB').`
- Decoded to `str` at all 12 affected sites across `display_cal.py`, `worker.py`, `wx_lut_viewer.py`, `wx_lut_3d_frame.py`, `wx_synth_icc_frame.py`, `wx_report_frame.py`, and `wx_profile_info.py`. For the two sites reusing the same value twice, decoded once into a local variable.
- Verified the one existing correctly-decoding call site (`display_cal.py`'s `validate_icc_profile()`) needed no change.

This was cosmetic only, not a functional bug — `lang.getstr()` calls `str()` on each `%s` var before substitution, so it never raised; it just rendered the Python `bytes` repr instead of the plain value.

Fixes #815

## Test plan
- [x] `python -m py_compile` on all 7 modified files
- [x] Manual review of each of the 12 call sites' diff against the issue's list