### PR TITLE
[#820] Fix four bytes/str bugs making load_cal_handler's 3D LUT config-mapper block dead code

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -19871,7 +19871,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
             return
 
         profile, ti3_lines = self.parse_calibration_file(path)
-        if profile is None or ti3_lines is None:
+        if ti3_lines is None:
             return
         setcfg("last_cal_or_icc_path", path)
         update_ccmx_items = True
@@ -20245,31 +20245,31 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                             locals()[local_var_name] = return_value
 
             setcfg("calibration.file", path)
-            if "CTI3" in ti3_lines:
+            if b"CTI3" in ti3_lines:
                 debug_print("[D] load_cal_handler testchart.file:", path)
                 setcfg("testchart.file", path)
-            if 'USE_BLACK_POINT_COMPENSATION "YES"' in ti3_lines:
+            if b'USE_BLACK_POINT_COMPENSATION "YES"' in ti3_lines:
                 setcfg("profile.black_point_compensation", 1)
-            elif 'USE_BLACK_POINT_COMPENSATION "NO"' in ti3_lines and (
+            elif b'USE_BLACK_POINT_COMPENSATION "NO"' in ti3_lines and (
                 sys.platform != "darwin" or not is_preset or is_3dlut_preset
             ):
                 # Only disable BPC if not OS X, or if a preset,
                 # or if a 3D LUT preset
                 setcfg("profile.black_point_compensation", 0)
-            if 'HIRES_B2A "YES"' in ti3_lines:
+            if b'HIRES_B2A "YES"' in ti3_lines:
                 setcfg("profile.b2a.hires", 1)
-            elif 'HIRES_B2A "NO"' in ti3_lines:
+            elif b'HIRES_B2A "NO"' in ti3_lines:
                 setcfg("profile.b2a.hires", 0)
-            if 'SMOOTH_B2A "YES"' in ti3_lines:
-                if 'HIRES_B2A "NO"' not in ti3_lines:
+            if b'SMOOTH_B2A "YES"' in ti3_lines:
+                if b'HIRES_B2A "NO"' not in ti3_lines:
                     setcfg("profile.b2a.hires", 1)
                 setcfg("profile.b2a.hires.smooth", 1)
-            elif 'SMOOTH_B2A "NO"' in ti3_lines:
-                if 'HIRES_B2A "YES"' not in ti3_lines:
+            elif b'SMOOTH_B2A "NO"' in ti3_lines:
+                if b'HIRES_B2A "YES"' not in ti3_lines:
                     setcfg("profile.b2a.hires", 0)
                 setcfg("profile.b2a.hires.smooth", 0)
             simset = False  # Only HDR 3D LUTs will have this set
-            if "BEGIN_DATA_FORMAT" in ti3_lines:
+            if b"BEGIN_DATA_FORMAT" in ti3_lines:
                 cfgend = ti3_lines.index(b"BEGIN_DATA_FORMAT")
                 cfgpart = CGATS(b"\n".join(ti3_lines[:cfgend]))
                 lut3d_trc_set = False
@@ -20364,7 +20364,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                                 # smallest testchart.
                                 cfgvalue = 1
                         elif keyword == "PATCH_SEQUENCE":
-                            cfgvalue = cfgvalue.lower().replace("_rgb_", "_RGB_")
+                            cfgvalue = cfgvalue.lower().replace(b"_rgb_", b"_RGB_")
                         elif keyword == "3DLUT_GAMMA":
                             try:
                                 cfgvalue = float(cfgvalue)
@@ -20382,7 +20382,7 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                                 setcfg("measurement_report.apply_black_offset", 0)
                                 setcfg("measurement_report.apply_trc", 1)
                         elif keyword == "3DLUT_GAMUT_MAPPING_MODE":
-                            cfgvalue = 0 if cfgvalue == "G" else 1
+                            cfgvalue = 0 if cfgvalue == b"G" else 1
                         elif keyword in (
                             "FFP_INSERTION_INTERVAL",
                             "FFP_INSERTION_DURATION",
@@ -20394,7 +20394,11 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                             setcfg("3dlut.tab.enable", 1)
                             setcfg("3dlut.tab.enable.backup", 1)
                     if cfgvalue is not None:
-                        cfgvalue = str(cfgvalue)
+                        cfgvalue = (
+                            cfgvalue.decode("utf-8")
+                            if isinstance(cfgvalue, bytes)
+                            else str(cfgvalue)
+                        )
                         if cfgname.endswith("profile") and (
                             not os.path.isabs(cfgvalue) or not os.path.isfile(cfgvalue)
                         ):
@@ -20448,7 +20452,11 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                         cfgvalue = cfgpart.queryv1(keyword)
                         if cfgvalue is None:
                             continue
-                        cfgvalue = str(cfgvalue)
+                        cfgvalue = (
+                            cfgvalue.decode("utf-8")
+                            if isinstance(cfgvalue, bytes)
+                            else str(cfgvalue)
+                        )
                         with contextlib.suppress(ValueError):
                             cfgvalue = round(float(cfgvalue), 4)
                         setcfg(

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -620,3 +620,88 @@ def test_import_session_archive_producer_returns_extracted_file_extension(
 
     assert not isinstance(result, Exception)
     assert result == os.path.join(getcfg("profile.save_path"), basename, f"{basename}.cal")
+
+
+def test_load_cal_handler_proceeds_for_cal_files_with_no_profile(
+    data_files, mainframe: MainFrame, monkeypatch
+) -> None:
+    """Regression test for issue #820.
+
+    ``parse_calibration_file()`` only ever returns a non-``None`` ``profile``
+    for ``.icc``/``.icm`` paths (it stays ``None`` for ``.cal`` files, which
+    have no embedded ``ICCProfile`` at all). But ``load_cal_handler()``'s
+    early-out checked ``if profile is None or ti3_lines is None: return``,
+    so it always bailed before doing anything for every ``.cal`` file,
+    regardless of whether it parsed successfully. Only ``ti3_lines`` (the
+    actual parse-failure signal) should gate the early return.
+    """
+    monkeypatch.setattr(
+        display_cal, "check_set_argyll_bin", lambda *args, **kwargs: True
+    )
+    # load_cal_handler() bails immediately if a previous test left this set;
+    # it is unrelated to the bug under test here.
+    setcfg("settings.changed", 0)
+    path = str(
+        data_files[
+            "UP2516D #1 2022-03-20 02-08 D6500 2.2 F-S XYZLUT+MTX.cal"
+        ].absolute()
+    )
+
+    mainframe.load_cal_handler(None, path=path)
+
+    assert getcfg("last_cal_or_icc_path") == path
+
+
+def test_load_cal_handler_config_mapper_block_bytes_str_bugs(
+    data_files, tmp_path, mainframe: MainFrame, monkeypatch
+) -> None:
+    """Regression test for issue #820.
+
+    Covers all four bugs in ``load_cal_handler()``'s 3D LUT / profile-B2A
+    config-mapper block (the ``BEGIN_DATA_FORMAT``-guarded block that reads
+    ``PATCH_SEQUENCE``, ``3DLUT_GAMUT_MAPPING_MODE``, etc. from a saved
+    ``.cal``/profile file):
+
+    1. ``"BEGIN_DATA_FORMAT" in ti3_lines`` compared a ``str`` literal
+       against ``ti3_lines`` (``list[bytes]``), so the whole block, along
+       with the five smaller ``ti3_lines`` checks above it, was unreachable
+       dead code.
+    2. ``cfgvalue = 0 if cfgvalue == "G" else 1`` compared ``bytes`` against
+       a ``str`` literal, always forcing ``3dlut.gamap.use_b2a`` to ``1``.
+    3. ``cfgvalue.lower().replace("_rgb_", "_RGB_")`` called ``bytes``
+       methods with ``str`` arguments, raising ``TypeError`` for
+       ``PATCH_SEQUENCE``.
+    4. ``cfgvalue = str(cfgvalue)`` stringified the ``bytes`` repr (e.g.
+       ``"b'...'"``) instead of decoding it, corrupting every keyword
+       ``CGATS.queryv1()`` left as ``bytes``.
+
+    Builds a ``.cal`` file from a real fixture with ``PATCH_SEQUENCE`` and
+    ``3DLUT_GAMUT_MAPPING_MODE`` keywords inserted ahead of the first
+    ``BEGIN_DATA_FORMAT`` marker (mirroring how Argyll writes these), then
+    asserts both end up correctly decoded/mapped instead of at their
+    (different) config defaults.
+    """
+    monkeypatch.setattr(
+        display_cal, "check_set_argyll_bin", lambda *args, **kwargs: True
+    )
+    # load_cal_handler() bails immediately if a previous test left this set;
+    # it is unrelated to the bugs under test here.
+    setcfg("settings.changed", 0)
+    fixture_path = data_files[
+        "UP2516D #1 2022-03-20 02-08 D6500 2.2 F-S XYZLUT+MTX.cal"
+    ]
+    lines = fixture_path.read_bytes().split(b"\n")
+    data_format_index = lines.index(b"BEGIN_DATA_FORMAT")
+    lines[data_format_index:data_format_index] = [
+        b'PATCH_SEQUENCE "MAXIMIZE_RGB_DIFFERENCE"',
+        b'3DLUT_GAMUT_MAPPING_MODE "G"',
+    ]
+    cal_path = tmp_path / fixture_path.name
+    cal_path.write_bytes(b"\n".join(lines))
+
+    mainframe.load_cal_handler(None, path=str(cal_path))
+
+    # Defaults are "optimize_display_response_delay" / 1, so these values
+    # only end up here if the block ran and decoded/compared correctly.
+    assert getcfg("testchart.patch_sequence") == "maximize_RGB_difference"
+    assert getcfg("3dlut.gamap.use_b2a") == 0

--- a/tests/test_display_cal.py
+++ b/tests/test_display_cal.py
@@ -690,7 +690,11 @@ def test_load_cal_handler_config_mapper_block_bytes_str_bugs(
     fixture_path = data_files[
         "UP2516D #1 2022-03-20 02-08 D6500 2.2 F-S XYZLUT+MTX.cal"
     ]
-    lines = fixture_path.read_bytes().split(b"\n")
+    # splitlines() (not split(b"\n")) so this is robust to Windows checkouts
+    # where git's core.autocrlf normalizes this text fixture to CRLF,
+    # otherwise a trailing "\r" on every line would break the exact-bytes
+    # index() lookup below.
+    lines = fixture_path.read_bytes().splitlines()
     data_format_index = lines.index(b"BEGIN_DATA_FORMAT")
     lines[data_format_index:data_format_index] = [
         b'PATCH_SEQUENCE "MAXIMIZE_RGB_DIFFERENCE"',

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -663,35 +663,48 @@ def test_prepare_dispcal_1():
     # only fall back to config.DEFAULTS for options that were never set.
     # Other tests (in this module and others) call setcfg()/writecfg() and
     # leave options set for the rest of the pytest-xdist worker process;
-    # initcfg() alone does not clear them; it only merges whatever is on
+    # initcfg() alone does not clear them, it only merges whatever is on
     # disk into the same in-memory CFG. Under xdist, which tests ran earlier
     # on this worker is nondeterministic, so leftover options made the
     # hardcoded expected_result below flaky (e.g. a stray
     # "calibration.black_point_correction.auto" left truthy silently drops
-    # the "-k0.0" arg, shifting every index after it). Explicitly clear
-    # every currently-set option so this test starts from a guaranteed
-    # config.DEFAULTS state.
+    # the "-k0.0" arg, shifting every index after it).
+    #
+    # Snapshot and clear every option currently set in config.CFG's
+    # "Default" section (the config module monkeypatches
+    # configparser.DEFAULTSECT to "Default", so that's the real section
+    # setcfg()/getcfg() read and write) so this test starts from a
+    # guaranteed config.DEFAULTS state, then restore the snapshot afterwards
+    # so we don't clobber session-scoped state other tests depend on (e.g.
+    # the setup_argyll fixture's "argyll.dir"/"argyll.version").
+    original_cfg = dict(config.CFG["Default"])
     for name in list(config.CFG["Default"]):
         setcfg(name, None)
-    worker = Worker()
-    return_val = worker.prepare_dispcal()
-    expected_result = [
-        "-v2",
-        "-d0",
-        "-c1",
-        return_val[1][3],  # '-yl',
-        return_val[1][4],  # '-P0.5,0.5,1.0',
-        "-ql",
-        return_val[1][6],  # '-t',
-        "-g2.2",
-        "-f1.0",
-        return_val[1][9],  # '-k0.0',
-        "/var/folders/8l/xy1__ym94nn35x86xyg56xq80000gn/T/DisplayCAL-2fdjtyql/",
-    ]
-    assert return_val[0] == get_argyll_util("dispcal")
-    assert isinstance(return_val[1], list)
-    assert return_val[1][:-1] == expected_result[:-1]  # don't check the final part
-    assert tempfile.gettempdir() in return_val[1][-1]  # this should be in a temp path
+    try:
+        worker = Worker()
+        return_val = worker.prepare_dispcal()
+        expected_result = [
+            "-v2",
+            "-d0",
+            "-c1",
+            return_val[1][3],  # '-yl',
+            return_val[1][4],  # '-P0.5,0.5,1.0',
+            "-ql",
+            return_val[1][6],  # '-t',
+            "-g2.2",
+            "-f1.0",
+            return_val[1][9],  # '-k0.0',
+            "/var/folders/8l/xy1__ym94nn35x86xyg56xq80000gn/T/DisplayCAL-2fdjtyql/",
+        ]
+        assert return_val[0] == get_argyll_util("dispcal")
+        assert isinstance(return_val[1], list)
+        assert return_val[1][:-1] == expected_result[:-1]  # don't check the final part
+        assert tempfile.gettempdir() in return_val[1][-1]  # in a temp path
+    finally:
+        for name in list(config.CFG["Default"]):
+            setcfg(name, None)
+        for name, value in original_cfg.items():
+            setcfg(name, value)
 
 
 @pytest.mark.skipif(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -659,14 +659,20 @@ def test_prepare_colprof_for_271(monkeypatch, data_path):
 
 def test_prepare_dispcal_1():
     """Worker.prepare_dispcal() return value should be quoted properly."""
-    # Reset to defaults: prepare_dispcal() reads its args from the global
-    # config, and other tests in this module leave keys (e.g.
-    # "display.number") mutated without restoring them. Under xdist,
-    # scheduling is nondeterministic, so which tests ran earlier on this
-    # worker (and thus which cfg values are still dirty) varies from run to
-    # run, making the hardcoded expected_result below flaky unless we start
-    # from a known-clean state.
-    initcfg()
+    # prepare_dispcal() builds its arg list from many getcfg() calls, which
+    # only fall back to config.DEFAULTS for options that were never set.
+    # Other tests (in this module and others) call setcfg()/writecfg() and
+    # leave options set for the rest of the pytest-xdist worker process;
+    # initcfg() alone does not clear them; it only merges whatever is on
+    # disk into the same in-memory CFG. Under xdist, which tests ran earlier
+    # on this worker is nondeterministic, so leftover options made the
+    # hardcoded expected_result below flaky (e.g. a stray
+    # "calibration.black_point_correction.auto" left truthy silently drops
+    # the "-k0.0" arg, shifting every index after it). Explicitly clear
+    # every currently-set option so this test starts from a guaranteed
+    # config.DEFAULTS state.
+    for name in list(config.CFG["Default"]):
+        setcfg(name, None)
     worker = Worker()
     return_val = worker.prepare_dispcal()
     expected_result = [

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -659,6 +659,14 @@ def test_prepare_colprof_for_271(monkeypatch, data_path):
 
 def test_prepare_dispcal_1():
     """Worker.prepare_dispcal() return value should be quoted properly."""
+    # Reset to defaults: prepare_dispcal() reads its args from the global
+    # config, and other tests in this module leave keys (e.g.
+    # "display.number") mutated without restoring them. Under xdist,
+    # scheduling is nondeterministic, so which tests ran earlier on this
+    # worker (and thus which cfg values are still dirty) varies from run to
+    # run, making the hardcoded expected_result below flaky unless we start
+    # from a known-clean state.
+    initcfg()
     worker = Worker()
     return_val = worker.prepare_dispcal()
     expected_result = [


### PR DESCRIPTION
## Summary

- `load_cal_handler()`'s config-mapper block (restores 3D LUT metadata and profile-B2A flags when reloading a saved profile/`.cal` file) was unreachable dead code: its own guard, `"BEGIN_DATA_FORMAT" in ti3_lines` (and five smaller checks above it), compared a `str` literal against `ti3_lines`, a `list[bytes]`, which is always `False` in Python 3.
- Fixes three more latent bugs that surface once that guard is fixed: `3DLUT_GAMUT_MAPPING_MODE`'s `bytes`-vs-`str` comparison always forced `3dlut.gamap.use_b2a` to `1`; `PATCH_SEQUENCE`'s `cfgvalue.lower().replace("_rgb_", "_RGB_")` called `bytes.replace()` with `str` args, raising `TypeError`; and `cfgvalue = str(cfgvalue)` stringified the `bytes` repr (e.g. `"b'-1'"`) instead of decoding it.
- Also fixes a related bug found while testing: `load_cal_handler()`'s `if profile is None or ti3_lines is None: return` always bailed for every `.cal` file, since `parse_calibration_file()` only ever returns a non-`None` `profile` for `.icc`/`.icm` paths. This silently no-oped every `.cal` reload and was blocking the fix above from being reachable at all for `.cal` files.

All four bugs were already fixed on the `7-move-the-ui-to-qt` branch (commit `5ebe757b`) while porting this block to Qt; this reapplies the same `display_cal.py` fix to `develop`, plus the newly found early-return bug that branch's toolkit-neutral `parse_calibration_file()` avoids by design.

Closes #820

## Test plan

- [x] Two new regression tests in `tests/test_display_cal.py` exercise `load_cal_handler()` end-to-end against real and synthetic `.cal` fixtures; both fail on the pre-fix code and pass with the fix.
- [x] Full test suite (`pytest -n auto`): 1000 passed, 19 skipped (pre-existing).