### PR TITLE
Fixes macOS first measurement crash

### DIFF
--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -11090,6 +11090,12 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
         elif not self.setup_patterngenerator(self):
             return
         writecfg()
+        if sys.platform == "darwin":
+            # Pre-create worker measurement sounds on the main thread. On
+            # macOS, first-time sound/backend setup from the worker thread can
+            # trigger Cocoa initialization via ctypes and crash.
+            with contextlib.suppress(Exception):
+                self.worker._init_sounds(dummy=False)
         if pending_function_kwargs.get("wrapup", True):
             self.worker.wrapup(False)
         pending_function_kwargs.pop("wrapup", None)


### PR DESCRIPTION
Fix for #822

Strange bug since it only happens in the macOS packaged `DisplayCAL.app` bundle. Never had this issue in 3.9.17 or running the develop branch `displaycal.pyw `from the command line.

Copilot looked at the crash reports and proposed this fix in the audio initialization, which must be for the optional shutter sound during measurements. I used `py2app` to make a new local bundled .app that included the fix and it solved the crash for me. I then doubled-checked the issue on a clean install of 26.5.1 on a separate partition. Confirmed that the 3.9.18 release did have the bug and my patched .app did not. 

I'd welcome anyone else to test this and verify the fix. I'll include some snippets of Copilot's explanation below.

> Cause identified from the crash report and code paths:
> 
> 1. The crash is an AppKit thread-affinity violation.
> 2. In your report, the crashing thread is not the main UI thread, and the top frames show AppKit window creation via ctypes:
> - NSWindow init in crash stack
> - called from _ctypes
> - on Thread 9 (worker thread), not Thread 0
> 
> That matches a known pattern: Cocoa/AppKit UI objects must be created on the main thread.
> 
> The first non-interactive measurements can initialize measurement sound objects inside the worker thread, while Calibrate & Profile often initializes equivalent sound/UI on the main thread first. I’m going to switch the fix to pre-create the worker’s measurement sounds on macOS main thread in setup_measurement so that worker startup no longer does first-time sound object creation.
> 
> 1. Crash stack is AppKit NSWindow via [_ctypes](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on worker thread.
> 2. Non-interactive measurement workflows can start worker thread before progress UI is fully initialized.
> 3. Worker path may first-create measurement sound objects in worker thread.
> 4. Calibrate & Profile often initializes interactive/progress UI first (main-thread path), which aligns with why it avoids first-run crash.
> 
> This change forces that first sound-object initialization to happen on the main thread in all measurement setup paths.
> 