### PR TITLE
Retry the wxPython wheel/package download in CI up to 3 times

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -100,9 +100,19 @@ jobs:
 
     - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
+        set -euo pipefail
         py_version="${{ matrix.python-version }}"
         py_version="${py_version//./}"
-        uv pip install --system "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxpython-${{ env.WX_VERSION }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
+        wx_url="https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04/wxpython-${{ env.WX_VERSION }}-cp${py_version}-cp${py_version}-linux_x86_64.whl"
+        for attempt in 1 2 3; do
+          if uv pip install --system "${wx_url}"; then
+            break
+          fi
+          if [ "${attempt}" -eq 3 ]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -180,7 +180,17 @@ jobs:
 
     - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ env.WX_VERSION }}
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+          uv pip install --system wxPython==${{ env.WX_VERSION }}
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq 3) {
+            exit 1
+          }
+          Start-Sleep -Seconds ($attempt * 10)
+        }
+      shell: pwsh
 
     - name: Install Python dependencies
       run: |
@@ -247,7 +257,16 @@ jobs:
 
     - name: Install wxPython ${{ env.WX_VERSION }}
       run: |
-        uv pip install --system wxPython==${{ env.WX_VERSION }}
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if uv pip install --system wxPython==${{ env.WX_VERSION }}; then
+            break
+          fi
+          if [ "${attempt}" -eq 3 ]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
 
     - name: Install Python dependencies
       run: |


### PR DESCRIPTION
## Summary

- The Linux, macOS, and Windows CI jobs each install wxPython in a single \`uv pip install\` call with no retry (Linux from a direct wheel URL on \`extras.wxpython.org\`, macOS/Windows from PyPI), so a transient network blip fails the whole job.
- Wraps each in a retry-with-backoff loop (3 attempts): the Linux/macOS jobs reuse the same bash pattern already used for \`apt-get install\` a few steps above in the Linux job; Windows gets an equivalent PowerShell loop, matching that job's existing \`pwsh\` convention.

## Test plan

- [x] \`.github/workflows/pytest.yml\` YAML validated with \`yaml.safe_load\`
- [x] Loop logic mirrors the already-in-use \`apt-get install\` retry pattern in the same file