### PR TITLE
[#846] Fix Verification tab chart-edit button targeting the wrong testchart

### DIFF
--- a/DisplayCAL/ui/main_window.py
+++ b/DisplayCAL/ui/main_window.py
@@ -1176,6 +1176,14 @@ class MainWindow(BaseWindow):
         self._testchart_paths: list[str] = []
         self._current_testchart_path: str | None = None
         self._testchart_editor_window: TestchartEditorWindow | None = None
+        #: Separate singleton for the Verification tab's chart-edit button
+        #: (:meth:`_open_report_testchart_editor`), bound to
+        #: ``measurement_report.chart`` -- kept apart from
+        #: ``_testchart_editor_window`` (bound to ``testchart.file``) so
+        #: editing the report's chart never clobbers the Profiling tab's,
+        #: mirroring wx's separate ``ReportFrame.tcframe`` vs.
+        #: ``MainFrame.tcframe`` instances.
+        self._report_testchart_editor_window: TestchartEditorWindow | None = None
         self._synthicc_window: SynthICCWindow | None = None
         self._lut3d_window: LUT3DWindow | None = None
         self._curve_viewer_window: CurveViewerWindow | None = None
@@ -4280,7 +4288,9 @@ class MainWindow(BaseWindow):
         self._report_panel = ReportPanel(
             self, show_measure_button=False, worker=self.worker
         )
-        self._report_panel.edit_chart_requested.connect(self._open_testchart_editor)
+        self._report_panel.edit_chart_requested.connect(
+            self._open_report_testchart_editor
+        )
         return self._report_panel
 
     #: Rounder pill-style corners for the bottom action buttons, closer to
@@ -6774,6 +6784,34 @@ class MainWindow(BaseWindow):
         if first_open:
             window = TestchartEditorWindow()
             self._testchart_editor_window = window
+        if path != "auto" and (
+            first_open or window.ti1 is None or window.ti1.filename != path
+        ):
+            window.load_file(path)
+        window.show()
+        window.raise_()
+        window.activateWindow()
+
+    def _open_report_testchart_editor(self) -> None:
+        """Show the testchart editor bound to the Verification tab's chart.
+
+        Qt port of wx's ``ReportPanel.chart_btn_handler``
+        (``DisplayCAL/wx_report_frame.py:342-363``): opens a chart editor
+        instance dedicated to ``measurement_report.chart``, distinct from
+        :meth:`_open_testchart_editor`'s Profiling-tab singleton, so saving
+        a chart here can only ever retarget the report's chart (via
+        :meth:`~DisplayCAL.ui.measurement_report.ReportPanel.mr_set_testchart`),
+        never ``testchart.file``.
+        """
+        path = getcfg("measurement_report.chart")
+        window = self._report_testchart_editor_window
+        first_open = window is None
+        if first_open:
+            window = TestchartEditorWindow(
+                cfg="measurement_report.chart",
+                chart_selected_callback=self._report_panel.mr_set_testchart,
+            )
+            self._report_testchart_editor_window = window
         if path != "auto" and (
             first_open or window.ti1 is None or window.ti1.filename != path
         ):

--- a/DisplayCAL/ui/tools/testchart_editor.py
+++ b/DisplayCAL/ui/tools/testchart_editor.py
@@ -372,7 +372,26 @@ class TestchartEditorWindow(BaseWindow):
     #: Grid columns holding editable device values.
     _RGB_COLUMNS = ("R %", "G %", "B %")
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        cfg: str = "testchart.file",
+        chart_selected_callback: Callable[[str], None] | None = None,
+    ) -> None:
+        """Initialize the testchart editor window.
+
+        Args:
+            cfg: Config key the editor's active chart is bound to. Defaults
+                to the Profiling tab's ``testchart.file``; the Verification
+                tab's editor passes ``measurement_report.chart`` instead so
+                saving-as offers to (and, once confirmed, does) retarget the
+                report's chart rather than the profiling one.
+            chart_selected_callback: Called with the saved path once it
+                matches ``cfg``, mirroring wx's
+                ``parent_set_chart_methodname`` -- lets the caller (e.g.
+                :meth:`ReportPanel.mr_set_testchart
+                <DisplayCAL.ui.measurement_report.ReportPanel.mr_set_testchart>`)
+                react to the newly selected chart.
+        """
         super().__init__(
             name="tcgen",
             title=lang.getstr("testchart.edit"),
@@ -381,7 +400,8 @@ class TestchartEditorWindow(BaseWindow):
         self.worker = Worker()
         self.worker.set_argyll_version("targen")
         self.argyll_version = self.worker.argyll_version
-        self.cfg = "testchart.file"
+        self.cfg = cfg
+        self._chart_selected_callback = chart_selected_callback
         self.ti1: CGATS | None = None
         self.tc_amount = 0
         self._loading = False
@@ -2730,7 +2750,31 @@ END_DATA"""
             f"{lang.getstr('testchart.edit').rstrip('.')}: {os.path.basename(path)}"
         )
         self.save_btn.setEnabled(False)
+        if self._chart_selected_callback is not None:
+            if path != getcfg(self.cfg) and self._confirm_select_chart():
+                setcfg(self.cfg, path)
+                self.writecfg()
+            if path == getcfg(self.cfg):
+                self._chart_selected_callback(path)
         return True
+
+    def _confirm_select_chart(self) -> bool:
+        """Ask whether the just-saved chart should become the active one.
+
+        Mirrors wx's ``tc_save_as_handler`` confirm dialog, shown only when
+        saving as a path different from the bound ``cfg`` key's current
+        value (e.g. the Verification tab's ``measurement_report.chart``).
+        """
+        box = QMessageBox(self)
+        box.setWindowTitle(self.windowTitle())
+        box.setIcon(QMessageBox.Question)
+        box.setText(lang.getstr("testchart.confirm_select"))
+        ok_button = box.addButton(
+            lang.getstr("testchart.select"), QMessageBox.AcceptRole
+        )
+        box.addButton(lang.getstr("testchart.dont_select"), QMessageBox.RejectRole)
+        message_box.exec_box(box)
+        return box.clickedButton() is ok_button
 
     def tc_clear(self) -> None:
         """Discard the current chart and reset the editor."""

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -1500,13 +1500,15 @@ def test_measurement_report_btn_handler_runs_report_self_check_with_alt(
     assert calls == [True]
 
 
-def test_report_panel_edit_chart_requested_opens_testchart_editor(window):
+def test_report_panel_edit_chart_requested_opens_report_testchart_editor(window):
     try:
         window._report_panel.edit_chart_requested.emit()
-        assert window._testchart_editor_window is not None
+        assert window._report_testchart_editor_window is not None
+        assert window._testchart_editor_window is None
+        assert window._report_testchart_editor_window.cfg == "measurement_report.chart"
     finally:
-        if window._testchart_editor_window is not None:
-            window._testchart_editor_window.close()
+        if window._report_testchart_editor_window is not None:
+            window._report_testchart_editor_window.close()
 
 
 def _fake_report_context(**overrides):

--- a/tests/test_ui_testchart_editor_report_chart.py
+++ b/tests/test_ui_testchart_editor_report_chart.py
@@ -1,0 +1,208 @@
+"""Tests for issue #846: the Verification tab's chart-edit button used to
+open/edit the wrong testchart.
+
+wx's ``TestchartEditor`` binds each editor instance to a ``cfg`` config key
+and a ``parent_set_chart_methodname`` callback (``DisplayCAL/wx_testchart_editor.py``),
+so saving a chart from the report's editor retargets
+``measurement_report.chart`` (via ``ReportFrame.mr_set_testchart``) rather
+than the Profiling tab's ``testchart.file``. The Qt port's
+``TestchartEditorWindow`` had no such parameters at all -- these tests
+exercise the ported ``cfg``/``chart_selected_callback`` wiring directly.
+"""
+
+import os
+
+import pytest
+
+from DisplayCAL import config
+from DisplayCAL import localization as lang
+from DisplayCAL.config import getcfg, setcfg
+
+# Run headless: pick the offscreen platform before any Qt import.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+os.environ.setdefault("QT_API", "pyside6")
+
+pytest.importorskip("qtpy")
+
+from DisplayCAL.cgats import CGATS  # noqa: E402
+from DisplayCAL.ui.tools import testchart_editor as te  # noqa: E402
+
+_TI1 = b"""CTI1
+
+NUMBER_OF_FIELDS 7
+BEGIN_DATA_FORMAT
+SAMPLE_ID RGB_R RGB_G RGB_B XYZ_X XYZ_Y XYZ_Z
+END_DATA_FORMAT
+NUMBER_OF_SETS 4
+BEGIN_DATA
+1 0.000000 0.000000 0.000000 0 0 0
+2 25.000000 25.000000 25.000000 5 5 5
+3 50.000000 50.000000 50.000000 10 10 10
+4 100.000000 100.000000 100.000000 20 20 20
+END_DATA
+"""
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Provide a singleton offscreen QApplication for the test session."""
+    from qtpy.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def _init():
+    """Config + localization must be live for the localized read-outs."""
+    config.initcfg()
+    lang.init()
+    yield
+
+
+class _FakeConfirmMessageBox:
+    """Stand-in for ``te.QMessageBox`` used by ``_confirm_select_chart``."""
+
+    Question = 0
+    AcceptRole = 1
+    RejectRole = 2
+
+    clicked_role = None  # "ok" | "cancel", set per-test
+
+    def __init__(self, parent=None):
+        self._buttons = {}
+
+    def setWindowTitle(self, title):
+        pass
+
+    def setIcon(self, icon):
+        pass
+
+    def setText(self, text):
+        self.text = text
+
+    def addButton(self, text, role):
+        button = (text, role)
+        self._buttons[role] = button
+        return button
+
+    def exec_(self):
+        return None
+
+    def clickedButton(self):
+        role = {"ok": self.AcceptRole, "cancel": self.RejectRole}[self.clicked_role]
+        return self._buttons[role]
+
+
+def _loaded_window(qapp, tmp_path, **kwargs):
+    window = te.TestchartEditorWindow(**kwargs)
+    path = tmp_path / "source.ti1"
+    path.write_bytes(_TI1)
+    window.ti1 = CGATS(str(path))
+    return window
+
+
+def test_constructor_defaults_match_profiling_tab_chart(qapp):
+    window = te.TestchartEditorWindow()
+    try:
+        assert window.cfg == "testchart.file"
+        assert window._chart_selected_callback is None
+    finally:
+        window.close()
+
+
+def test_constructor_binds_report_chart_cfg_and_callback(qapp):
+    calls = []
+    window = te.TestchartEditorWindow(
+        cfg="measurement_report.chart",
+        chart_selected_callback=calls.append,
+    )
+    try:
+        assert window.cfg == "measurement_report.chart"
+        assert window._chart_selected_callback == calls.append
+    finally:
+        window.close()
+
+
+def test_save_as_without_callback_does_not_touch_cfg(qapp, tmp_path, monkeypatch):
+    """Default (Profiling-tab-style) construction: no confirm dialog, no cfg writes."""
+    monkeypatch.setattr(te, "QMessageBox", _FakeConfirmMessageBox)
+    setcfg("testchart.file", "auto")
+    window = _loaded_window(qapp, tmp_path)
+    try:
+        target = str(tmp_path / "out.ti1")
+        assert window.tc_save_as(target) is True
+        assert getcfg("testchart.file") == "auto"
+    finally:
+        window.close()
+
+
+def test_save_as_matching_cfg_invokes_callback_without_prompting(
+    qapp, tmp_path, monkeypatch
+):
+    """Saving to the path already active in ``cfg`` calls back with no prompt."""
+    monkeypatch.setattr(te, "QMessageBox", _FakeConfirmMessageBox)
+    target = str(tmp_path / "report.ti1")
+    setcfg("measurement_report.chart", target)
+    calls = []
+    window = _loaded_window(
+        qapp,
+        tmp_path,
+        cfg="measurement_report.chart",
+        chart_selected_callback=calls.append,
+    )
+    try:
+        assert window.tc_save_as(target) is True
+        assert calls == [target]
+    finally:
+        window.close()
+
+
+def test_save_as_different_path_confirmed_retargets_report_chart(
+    qapp, tmp_path, monkeypatch
+):
+    """Saving elsewhere prompts; confirming updates ``measurement_report.chart``
+    and calls back, mirroring wx's ``mr_set_testchart`` wiring."""
+    monkeypatch.setattr(te, "QMessageBox", _FakeConfirmMessageBox)
+    _FakeConfirmMessageBox.clicked_role = "ok"
+    original = str(tmp_path / "original.ti1")
+    setcfg("measurement_report.chart", original)
+    calls = []
+    window = _loaded_window(
+        qapp,
+        tmp_path,
+        cfg="measurement_report.chart",
+        chart_selected_callback=calls.append,
+    )
+    try:
+        target = str(tmp_path / "edited.ti1")
+        assert window.tc_save_as(target) is True
+        assert getcfg("measurement_report.chart") == target
+        assert calls == [target]
+    finally:
+        window.close()
+
+
+def test_save_as_different_path_declined_leaves_report_chart_untouched(
+    qapp, tmp_path, monkeypatch
+):
+    """Declining the confirm prompt leaves ``measurement_report.chart`` alone
+    and never calls back -- the report keeps showing its original chart."""
+    monkeypatch.setattr(te, "QMessageBox", _FakeConfirmMessageBox)
+    _FakeConfirmMessageBox.clicked_role = "cancel"
+    original = str(tmp_path / "original.ti1")
+    setcfg("measurement_report.chart", original)
+    calls = []
+    window = _loaded_window(
+        qapp,
+        tmp_path,
+        cfg="measurement_report.chart",
+        chart_selected_callback=calls.append,
+    )
+    try:
+        target = str(tmp_path / "edited.ti1")
+        assert window.tc_save_as(target) is True
+        assert getcfg("measurement_report.chart") == original
+        assert calls == []
+    finally:
+        window.close()


### PR DESCRIPTION
## Summary

- Fixes #846: the Verification tab's chart-edit (pencil) button silently opened/edited the Profiling tab's `testchart.file` instead of the report's own `measurement_report.chart`, and never wrote edits back.
- `TestchartEditorWindow` now accepts `cfg` and `chart_selected_callback` parameters, mirroring wx's `TestchartEditor(cfg=..., parent_set_chart_methodname=...)`; `tc_save_as()` prompts to retarget `cfg` when saving to a different path and invokes the callback once the saved path matches it.
- `main_window.py` gets a dedicated `_report_testchart_editor_window` singleton and `_open_report_testchart_editor()`, bound to `measurement_report.chart` with `ReportPanel.mr_set_testchart()` as the callback, wired to `edit_chart_requested` instead of the Profiling-tab opener.

## Test plan

- [x] Updated `test_report_panel_edit_chart_requested_opens_testchart_editor` (renamed) to assert the report-specific singleton is used instead of the Profiling tab's.
- [x] Added `tests/test_ui_testchart_editor_report_chart.py` covering `cfg`/`chart_selected_callback` binding and both the confirm/decline save-as paths.
- [x] Full relevant suite (`test_ui_testchart_editor*.py`, `test_ui_measurement_report.py`, `test_ui_main_window.py`) passes: 564 passed (one pre-existing, unrelated failure in `test_use_qt_ui_toggled_restarts_when_confirmed`, confirmed present on `develop` before this change too).