### PR TITLE
[#847] Fix Argyll version compared as string, not parsed version list

### DIFF
--- a/DisplayCAL/argyll.py
+++ b/DisplayCAL/argyll.py
@@ -561,6 +561,28 @@ def parse_argyll_version_string(argyll_version_string: str) -> list[int | str]:
     return argyll_version
 
 
+def argyll_version_at_least(argyll_version_string: str, min_version: str) -> bool:
+    """Return whether ``argyll_version_string`` is at least ``min_version``.
+
+    Compares parsed, numeric version components instead of the raw strings,
+    so double-digit components (e.g. ``"1.10.0"``) sort correctly instead of
+    lexicographically (where ``"1.10.0" < "1.3.3"``).
+
+    Args:
+        argyll_version_string (str): E.g. ``getcfg("argyll.version")``.
+        min_version (str): A dotted, purely numeric version, e.g. ``"1.6"``.
+
+    Returns:
+        bool: Whether ``argyll_version_string >= min_version``.
+    """
+    parsed = [
+        v
+        for v in parse_argyll_version_string(argyll_version_string)
+        if isinstance(v, int)
+    ]
+    return parsed >= [int(v) for v in min_version.split(".")]
+
+
 ARGYLLCMS_BINARIES_API_URL = (
     "https://api.github.com/repos/eoyilmaz/argyllcms-binaries/releases/latest"
 )

--- a/DisplayCAL/gamap_settings.py
+++ b/DisplayCAL/gamap_settings.py
@@ -14,6 +14,7 @@ without reading gamut-mapping widget state directly.
 from __future__ import annotations
 
 from DisplayCAL import config
+from DisplayCAL.argyll import argyll_version_at_least
 from DisplayCAL.argyll_names import INTENTS, VIEWCONDS
 
 #: Profile types whose gamut can be usefully remapped. Mirrors wx's
@@ -48,8 +49,8 @@ def viewcond_items(argyll_version: str) -> list[str]:
         v
         for v in VIEWCONDS
         if not (
-            (v == "pc" and argyll_version < "1.1.1")
-            or (v == "tv" and argyll_version < "1.6")
+            (v == "pc" and not argyll_version_at_least(argyll_version, "1.1.1"))
+            or (v == "tv" and not argyll_version_at_least(argyll_version, "1.6"))
         )
     ]
 
@@ -67,9 +68,9 @@ def intent_items(argyll_version: str) -> list[str]:
         list[str]: Rendering-intent codes, in wx's fixed display order.
     """
     items = list(INTENTS)
-    if argyll_version < "1.3.3":
+    if not argyll_version_at_least(argyll_version, "1.3.3"):
         items.remove("pa")
-    if argyll_version < "1.8.3":
+    if not argyll_version_at_least(argyll_version, "1.8.3"):
         items.remove("lp")
     return items
 

--- a/DisplayCAL/lut3d_settings.py
+++ b/DisplayCAL/lut3d_settings.py
@@ -44,6 +44,7 @@ import shutil
 from dataclasses import dataclass
 
 from DisplayCAL import colormath
+from DisplayCAL.argyll import argyll_version_at_least
 from DisplayCAL.argyll_names import VIDEO_ENCODINGS
 from DisplayCAL.config import PROFILE_EXT, get_data_path
 from DisplayCAL.meta import NAME as APPNAME
@@ -200,7 +201,7 @@ def compute_trc_visibility(
         content_colorspace_is_custom (bool): Whether the content-colorspace
             combo's selection is its trailing "custom" row.
     """
-    base_show = argyll_version >= "1.6"
+    base_show = argyll_version_at_least(argyll_version, "1.6")
     smpte2084 = trc.startswith("smpte2084")
     smpte2084r = trc == "smpte2084.rolloffclip"
     hlg = trc == "hlg"
@@ -391,7 +392,7 @@ def lut3d_encoding_codes(file_format: str, argyll_version: str) -> tuple[
     else:
         encodings = ["n"] if file_format == "dcl" else list(VIDEO_ENCODINGS)
     if (
-        argyll_version >= "1.7"
+        argyll_version_at_least(argyll_version, "1.7")
         and argyll_version != "1.7.0_beta"
         and file_format != "dcl"
     ):
@@ -410,7 +411,7 @@ def lut3d_encoding_controls_visible(argyll_version: str) -> bool:
     1.7.0 beta 3" clause has no effect on the result: every version it would
     exclude from the first OR-clause still satisfies the second).
     """
-    return argyll_version >= "1.6"
+    return argyll_version_at_least(argyll_version, "1.6")
 
 
 def lut3d_bitdepth_controls_visible(file_format: str) -> tuple[bool, bool]:

--- a/DisplayCAL/ui/main_window.py
+++ b/DisplayCAL/ui/main_window.py
@@ -174,6 +174,7 @@ from DisplayCAL import localization as lang
 from DisplayCAL import profile_name as profile_name_mod
 from DisplayCAL import report
 from DisplayCAL.argyll import (
+    argyll_version_at_least,
     check_argyll_bin,
     check_set_argyll_bin,
     get_argyll_util,
@@ -906,7 +907,7 @@ def lut3d_format_items(argyll_version: str = "0.0.0") -> list[tuple[str, str]]:
     return [
         (fmt, lang.getstr(f"3dlut.format.{fmt}"))
         for fmt in config.VALID_VALUES["3dlut.format"]
-        if fmt != "madVR" or argyll_version >= "1.6"
+        if fmt != "madVR" or argyll_version_at_least(argyll_version, "1.6")
     ]
 
 
@@ -919,7 +920,7 @@ def lut3d_rendering_intent_items(argyll_version: str = "0.0.0") -> list[tuple[st
     return [
         (ri, lang.getstr(f"gamap.intents.{ri}"))
         for ri in config.VALID_VALUES["3dlut.rendering_intent"]
-        if ri != "lp" or argyll_version >= "1.8.3"
+        if ri != "lp" or argyll_version_at_least(argyll_version, "1.8.3")
     ]
 
 

--- a/tests/test_gamap_settings.py
+++ b/tests/test_gamap_settings.py
@@ -23,6 +23,14 @@ def test_viewcond_items_modern_argyll_includes_pc_and_tv():
     assert "tv" in items
 
 
+def test_viewcond_items_double_digit_argyll_includes_pc_and_tv():
+    # Regression test for #847: "1.10.0" < "1.3.3" lexicographically, which
+    # wrongly hid "pc"/"tv" for Argyll releases with a double-digit component.
+    items = gs.viewcond_items("1.10.0")
+    assert "pc" in items
+    assert "tv" in items
+
+
 def test_viewcond_items_preserves_order():
     items = gs.viewcond_items("1.9.2")
     assert items == [
@@ -52,6 +60,14 @@ def test_intent_items_old_argyll_excludes_pa_and_lp():
 
 def test_intent_items_modern_argyll_includes_pa_and_lp():
     items = gs.intent_items("1.9.2")
+    assert "pa" in items
+    assert "lp" in items
+
+
+def test_intent_items_double_digit_argyll_includes_pa_and_lp():
+    # Regression test for #847: "1.10.0" < "1.8.3" lexicographically, which
+    # wrongly hid "pa"/"lp" for Argyll releases with a double-digit component.
+    items = gs.intent_items("1.10.0")
     assert "pa" in items
     assert "lp" in items
 

--- a/tests/test_lut3d_settings.py
+++ b/tests/test_lut3d_settings.py
@@ -114,6 +114,14 @@ def test_visibility_old_argyll_hides_everything():
     assert v.black_output_offset is False
 
 
+def test_visibility_double_digit_argyll_shows_everything():
+    # Regression test for #847: "1.10.0" < "1.6" lexicographically, which
+    # wrongly hid the TRC row for Argyll releases with a double-digit
+    # component.
+    v = _visibility(argyll_version="1.10.0")
+    assert v.trc_row is True
+
+
 def test_visibility_custom_gamma_shown_without_advanced_options():
     # "customgamma" is visible even without show_advanced_options (matches
     # wx: ``trc == "customgamma" or show_advanced_options``).
@@ -426,6 +434,13 @@ def test_lut3d_encoding_codes_omits_clip_wtw_for_old_argyll():
     assert "T" not in inputs
 
 
+def test_lut3d_encoding_codes_inserts_clip_wtw_for_double_digit_argyll():
+    # Regression test for #847: "1.10.0" < "1.7" lexicographically, which
+    # wrongly omitted "T" for Argyll releases with a double-digit component.
+    inputs, _outputs = l3d.lut3d_encoding_codes("cube", "1.10.0")
+    assert "T" in inputs
+
+
 def test_lut3d_encoding_codes_output_excludes_x_and_bigx():
     _inputs, outputs = l3d.lut3d_encoding_codes("cube", "1.9.0")
     assert "x" not in outputs
@@ -436,6 +451,11 @@ def test_lut3d_encoding_controls_visible_gated_on_argyll_1_6():
     assert l3d.lut3d_encoding_controls_visible("1.6.0") is True
     assert l3d.lut3d_encoding_controls_visible("1.9.0") is True
     assert l3d.lut3d_encoding_controls_visible("1.5.0") is False
+
+
+def test_lut3d_encoding_controls_visible_double_digit_argyll():
+    # Regression test for #847: "1.10.0" < "1.6" lexicographically.
+    assert l3d.lut3d_encoding_controls_visible("1.10.0") is True
 
 
 def test_lut3d_bitdepth_controls_visible():

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -262,6 +262,30 @@ def test_profile_types_cover_config_valid_values():
     assert values == set(config.VALID_VALUES["profile.type"])
 
 
+def test_lut3d_format_items_double_digit_argyll_includes_madvr():
+    # Regression test for #847: "1.10.0" < "1.6" lexicographically, which
+    # wrongly hid madVR for Argyll releases with a double-digit component.
+    values = {value for value, _label in mw.lut3d_format_items("1.10.0")}
+    assert "madVR" in values
+
+
+def test_lut3d_format_items_old_argyll_excludes_madvr():
+    values = {value for value, _label in mw.lut3d_format_items("1.5.0")}
+    assert "madVR" not in values
+
+
+def test_lut3d_rendering_intent_items_double_digit_argyll_includes_lp():
+    # Regression test for #847: "1.10.0" < "1.8.3" lexicographically, which
+    # wrongly hid "lp" for Argyll releases with a double-digit component.
+    values = {value for value, _label in mw.lut3d_rendering_intent_items("1.10.0")}
+    assert "lp" in values
+
+
+def test_lut3d_rendering_intent_items_old_argyll_excludes_lp():
+    values = {value for value, _label in mw.lut3d_rendering_intent_items("1.5.0")}
+    assert "lp" not in values
+
+
 # --- window construction / wiring ------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Fixes #847: `gamap_settings.py`'s `viewcond_items()`/`intent_items()` compared `getcfg("argyll.version")` as a raw string (`argyll_version < "1.3.3"`), which sorts lexicographically instead of numerically, so `"1.10.0" < "1.3.3"` is wrongly `True` and hides gamut-mapping intents/viewing conditions for Argyll releases with a double-digit version component.
- While fixing it, found and fixed the same bug pattern in two more places that share the root cause: `lut3d_settings.py` (`compute_trc_visibility()`, `lut3d_encoding_codes()`, `lut3d_encoding_controls_visible()`) and `ui/main_window.py` (`lut3d_format_items()`, `lut3d_rendering_intent_items()`), which wrongly hid 3D LUT options (madVR format, clip-WTW encoding, "Perceptual, LUT proof" intent) the same way.
- Added `argyll_version_at_least()` to `argyll.py`, a shared helper that compares parsed numeric version components (via the existing `parse_argyll_version_string()`) instead of raw strings, and switched all affected call sites to it.

## Test plan

- [x] Added regression tests exercising Argyll `1.10.0` (a version that sorted incorrectly under the old string comparison) to `tests/test_gamap_settings.py`, `tests/test_lut3d_settings.py`, and `tests/test_ui_main_window.py`.
- [x] `pytest tests/test_gamap_settings.py tests/test_lut3d_settings.py tests/test_ui_main_window.py -n auto` — 592 passed.
- [x] `ruff check` clean on all changed lines.