### PR TITLE
[#857] Seed Qt 3D LUT input-profile combo with bundled reference profiles

### DIFF
--- a/DisplayCAL/ui/tools/lut3d.py
+++ b/DisplayCAL/ui/tools/lut3d.py
@@ -169,7 +169,8 @@ class _ProfileBrowse(QWidget):
     def __init__(self, dialog_title: str = "", parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._dialog_title = dialog_title
-        self._committed = ""
+        self._current_path = ""
+        self._committed_text = ""
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self._combo = QComboBox()
@@ -190,7 +191,7 @@ class _ProfileBrowse(QWidget):
         Returns:
             str: The current path (may be empty).
         """
-        return self._combo.currentText()
+        return self._current_path
 
     @staticmethod
     def _display_name(path: str) -> str:
@@ -233,27 +234,43 @@ class _ProfileBrowse(QWidget):
     def set_path(self, path: str | None) -> None:
         """Set the current path without emitting :attr:`changed`.
 
+        The combo shows the friendly profile name for ``path`` (wx parity);
+        :meth:`path` keeps returning the real path regardless of what is
+        displayed.
+
         Args:
             path (str | None): The path to show (``None`` clears the field).
         """
         path = path or ""
         if path and self._combo.findData(path) == -1:
             self._combo.addItem(self._display_name(path), path)
-        self._committed = path
-        self._combo.setEditText(path)
+        self._current_path = path
+        self._committed_text = self._display_name(path) if path else ""
+        self._combo.setEditText(self._committed_text)
 
     def _on_activated(self, index: int) -> None:
         path = self._combo.itemData(index)
-        self._committed = path if path is not None else self._combo.currentText()
-        self._combo.setEditText(self._committed)
+        if path is None:
+            path = self._combo.currentText()
+        self._current_path = path
+        self._committed_text = self._display_name(path) if path else ""
+        self._combo.setEditText(self._committed_text)
         self.changed.emit()
 
     def _on_edit_finished(self) -> None:
         # editingFinished also fires on focus-out without changes; only react
-        # to an actual edit, mirroring the wx changeCallback.
-        if self._combo.currentText() != self._committed:
-            self._committed = self._combo.currentText()
-            self.changed.emit()
+        # to an actual edit, mirroring the wx changeCallback. A typed value
+        # is treated as a literal path (there is no name to resolve it from
+        # until it is committed).
+        text = self._combo.currentText()
+        if text == self._committed_text:
+            return
+        if text and self._combo.findData(text) == -1:
+            self._combo.addItem(self._display_name(text), text)
+        self._current_path = text
+        self._committed_text = self._display_name(text) if text else ""
+        self._combo.setEditText(self._committed_text)
+        self.changed.emit()
 
     def _on_browse(self) -> None:
         default_dir = os.path.dirname(self.path()) if self.path() else ""

--- a/DisplayCAL/ui/tools/lut3d.py
+++ b/DisplayCAL/ui/tools/lut3d.py
@@ -57,6 +57,7 @@ from DisplayCAL.argyll_names import VIDEO_ENCODINGS
 from DisplayCAL.config import (
     DEFAULTS,
     PROFILE_EXT,
+    get_data_path,
     get_verified_path,
     getcfg,
     setcfg,
@@ -191,6 +192,18 @@ class _ProfileBrowse(QWidget):
         """
         return self._combo.currentText()
 
+    def set_history(self, paths: list[str]) -> None:
+        """Seed the combo's drop-down list without changing the current text.
+
+        Args:
+            paths (list[str]): Paths to pre-populate the history with.
+        """
+        current = self._combo.currentText()
+        for path in paths:
+            if self._combo.findText(path) == -1:
+                self._combo.addItem(path)
+        self._combo.setEditText(current)
+
     def set_path(self, path: str | None) -> None:
         """Set the current path without emitting :attr:`changed`.
 
@@ -318,6 +331,9 @@ class LUT3DWindow(BaseWindow):
 
         # Row: input profile.
         self.input_profile_ctrl = _ProfileBrowse(lang.getstr("3dlut.input.profile"))
+        self.input_profile_ctrl.set_history(
+            get_data_path("ref", r"\.(icc|icm)$") or []
+        )
         self._add_row(
             QLabel(lang.getstr("3dlut.input.profile")), self.input_profile_ctrl
         )

--- a/DisplayCAL/ui/tools/lut3d.py
+++ b/DisplayCAL/ui/tools/lut3d.py
@@ -192,16 +192,42 @@ class _ProfileBrowse(QWidget):
         """
         return self._combo.currentText()
 
+    @staticmethod
+    def _display_name(path: str) -> str:
+        """Return a friendly display name for a path, wx ``GetName`` parity.
+
+        Args:
+            path (str): The file path to get the name for.
+
+        Returns:
+            str: The ICC profile description if available, else the file's
+                base name, translated.
+        """
+        name = None
+        if os.path.splitext(path)[1].lower() in (".icc", ".icm"):
+            try:
+                profile = ICCProfile(path)
+            except (OSError, ICCProfileInvalidError):
+                pass
+            else:
+                name = profile.getDescription()
+        if not name:
+            name = os.path.basename(path)
+        return lang.getstr(name)
+
     def set_history(self, paths: list[str]) -> None:
         """Seed the combo's drop-down list without changing the current text.
+
+        Each entry is shown by its friendly profile name (data holds the
+        real path), matching wx's ``SetHistory``/``GetName``.
 
         Args:
             paths (list[str]): Paths to pre-populate the history with.
         """
         current = self._combo.currentText()
         for path in paths:
-            if self._combo.findText(path) == -1:
-                self._combo.addItem(path)
+            if self._combo.findData(path) == -1:
+                self._combo.addItem(self._display_name(path), path)
         self._combo.setEditText(current)
 
     def set_path(self, path: str | None) -> None:
@@ -211,13 +237,15 @@ class _ProfileBrowse(QWidget):
             path (str | None): The path to show (``None`` clears the field).
         """
         path = path or ""
-        if path and self._combo.findText(path) == -1:
-            self._combo.addItem(path)
+        if path and self._combo.findData(path) == -1:
+            self._combo.addItem(self._display_name(path), path)
         self._committed = path
         self._combo.setEditText(path)
 
-    def _on_activated(self, _index: int) -> None:
-        self._committed = self._combo.currentText()
+    def _on_activated(self, index: int) -> None:
+        path = self._combo.itemData(index)
+        self._committed = path if path is not None else self._combo.currentText()
+        self._combo.setEditText(self._committed)
         self.changed.emit()
 
     def _on_edit_finished(self) -> None:


### PR DESCRIPTION
## Summary
- wx seeds the 3D LUT window's input-profile combo history with the bundled `ref/*.icc`/`*.icm` reference profiles (`wx_lut_3d_frame.py:1780`); the Qt port's `_ProfileBrowse` had no equivalent, leaving the dropdown empty.
- Added `_ProfileBrowse.set_history()` and seed `input_profile_ctrl` with `get_data_path("ref", r"\.(icc|icm)$")` at window construction, matching wx.
- The dropdown now shows each profile's friendly name (ICC description, falling back to the file's base name) instead of the raw path, and the combo's edit field shows that same friendly name for the currently-selected value, matching wx's `GetName()`/`FileBrowseButtonWithHistory` behavior. `path()` still resolves to the real file path for everything downstream (validation, `ICCProfile()` loading, etc).

Closes #857

## Test plan
- [x] `python -m pyflakes DisplayCAL/ui/tools/lut3d.py`
- [x] Verified in isolation (`_ProfileBrowse` standalone) that the drop-down lists friendly names, selecting an item resolves back to the real path, and `path()`/`set_path()` round-trip correctly
- [x] Verified in the live Qt `LUT3DWindow` that the input-profile combo is pre-seeded with 25 bundled reference profiles and displays the friendly name for the maintainer's saved default profile