### PR TITLE
[#913] Remove dual/duplicated metadata from DisplayCAL/setup.py

### DIFF
--- a/DisplayCAL/setup.py
+++ b/DisplayCAL/setup.py
@@ -86,10 +86,8 @@ from DisplayCAL.meta import (
     AUTHOR,
     AUTHOR_ASCII,
     AUTHOR_EMAIL,
-    DESCRIPTION,
     DEVELOPMENT_HOME_PAGE,
     DOMAIN,
-    LONG_DESCRIPTION,
     NAME,
     PY_MAXVERSION,
     PY_MINVERSION,
@@ -995,35 +993,19 @@ def setup() -> None:
 
     packages = [NAME, f"{NAME}.lib", f"{NAME}.lib.agw"]
 
+    # name/version/description/license/classifiers/readme/entry_points
+    # (gui_scripts) live in pyproject.toml's [project] table, which always
+    # wins over the corresponding keys here (setuptools applies it on top of
+    # whatever `distutils.core.setup(**attrs)`/`setuptools.setup(**attrs)` is
+    # given, confirmed empirically via sdist/wheel METADATA), so they are not
+    # duplicated in this dict.
     attrs = {
         "author": AUTHOR_ASCII,
         "author_email": AUTHOR_EMAIL,
-        "classifiers": [
-            "Development Status :: 5 - Production/Stable",
-            "Environment :: MacOS X",
-            "Environment :: Win32 (MS Windows)",
-            "Environment :: X11 Applications",
-            "Intended Audience :: End Users/Desktop",
-            "License :: OSI Approved :: GNU General Public License v3 "
-            "or later (GPLv3+)",
-            "Operating System :: OS Independent",
-            "Programming Language :: Python :: 3.9",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-            "Programming Language :: Python :: 3.14",
-            "Topic :: Multimedia :: Graphics",
-        ],
         "data_files": data_files,
-        "description": DESCRIPTION,
         "download_url": f"{DEVELOPMENT_HOME_PAGE}/releases/download/"
         f"{VERSION_STRING}/{NAME}-{VERSION_STRING}.tar.gz",
         "ext_modules": ext_modules,
-        "license": "GPL v3",
-        "long_description": LONG_DESCRIPTION,
-        "long_description_content_type": "text/x-rst",
-        "name": NAME,
         "packages": packages,
         "package_data": package_data,
         "package_dir": {NAME: NAME},
@@ -1044,20 +1026,8 @@ def setup() -> None:
     }
 
     if setuptools:
-        attrs["entry_points"] = {
-            "gui_scripts": [
-                "{} = {}.main:main{}".format(
-                    script,
-                    NAME,
-                    (
-                        ""
-                        if script == NAME.lower()
-                        else script[len(NAME) :].lower().replace("-", "_")
-                    ),
-                )
-                for script, desc in scripts
-            ]
-        }
+        # gui_scripts entry points live in pyproject.toml's
+        # [project.gui-scripts] table, which wins over anything set here.
         attrs["exclude_package_data"] = {NAME: []}
         attrs["include_package_data"] = (
             sys.platform in ("darwin", "win32") and not do_py2app


### PR DESCRIPTION
## Summary

Part of the PEP 517 build-system modernization (#911-#917), following #911 and #912. Closes #913.

`DisplayCAL/setup.py`'s `setup()` builds an `attrs` dict passed to `distutils.core.setup(**attrs)` (or `setuptools.setup(**attrs)` under `--use-setuptools`). This dict duplicated several fields that `pyproject.toml`'s `[project]` table already declares statically: `name`, `classifiers`, `description`, `license`, `long_description`/`long_description_content_type`, and `entry_points` (`gui_scripts`).

Empirically verified (via sdist `PKG-INFO` / wheel `METADATA` inspection) that **pyproject.toml already wins** for all of these fields on every real build path, both `python -m build` (PEP 517 frontend) and direct `python native_build.py sdist` invocation: whichever Python process builds this project has `setuptools` importable, and setuptools always monkeypatches `distutils.core.Distribution`, so the `Distribution` that actually gets constructed applies `pyproject.toml`'s static `[project]` metadata regardless of what `attrs` supplies. The `attrs` copies were dead code, and had already drifted (`license: "GPL v3"` vs. pyproject.toml's `GPL-3.0-or-later`; attrs had a `License ::` trove classifier pyproject.toml doesn't).

This PR removes the dead duplicate keys and their now-unused `DESCRIPTION`/`LONG_DESCRIPTION` imports, leaving a comment explaining why they're gone. Fields kept in `attrs` are ones with no `[project]` equivalent: `author`/`author_email` (fills the legacy plain-name `Author:` header), `download_url`, `ext_modules`, `platforms`, `requires`, `provides`, `version` (needed for the `bdist_msi` numeric-version override), `packages`/`package_data`/`data_files` (build config, not PEP 621 metadata, out of scope here).

## Verification

- `sdist` `PKG-INFO` is byte-identical before/after this change (`python native_build.py sdist`, diffed).
- Full fresh-clone two-phase build (`git clone` → `python -m build --sdist` → extract → `python -m build --wheel` from the extracted sdist): wheel's file list is identical to the same build from `develop` HEAD (pre-#913), and `METADATA`/`entry_points.txt` content is unchanged (name, version, classifiers, license expression, gui_scripts entry points all correct, still sourced from pyproject.toml as before).
- `dist/copyright` absence in the wheel is a pre-existing, unrelated condition confirmed present on `develop` HEAD too (not a regression from this change).

## Test plan

- [ ] CI green (Windows/macOS/Linux/Flatpak/pytest, nightly build)
- [ ] Spot-check an installed build's console scripts (`displaycal`, `displaycal-3dlut-maker`, etc.) still work