### PR TITLE
Revert pytest back to running concurrently in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -130,7 +130,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python -m pytest --verbose -W ignore --color=yes -m "not network" --durations=50
+        python -m pytest --verbose -n auto -W ignore --color=yes -m "not network" --durations=50
 
     - name: Dump thread stacks (diagnostic, see conftest.py)
       if: always()
@@ -215,7 +215,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python -m pytest --verbose -W ignore --color=yes -m "not network" --durations=50
+        python -m pytest --verbose -n auto -W ignore --color=yes -m "not network" --durations=50
 
   macos:
     name: macOS + Python ${{ matrix.python-version }}
@@ -287,7 +287,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python -m pytest --verbose -W ignore --color=yes -m "not network" --durations=50
+        python -m pytest --verbose -n auto -W ignore --color=yes -m "not network" --durations=50
 
     - name: Dump thread stacks (diagnostic, see conftest.py)
       if: always()


### PR DESCRIPTION
## Summary
- #925 tried running pytest serially (`-n auto` removed) across all three OS CI jobs, as an experiment to see whether it reduced the amount of randomly failing tests
- It didn't help, and serial execution is noticeably slower, so this reverts to `-n auto` on all three jobs, back to the exact pre-#925 state

## Test plan
- [x] CI green on this PR, confirming concurrent execution is back