### PR TITLE
[Docs] Update installation instructions for latest package formats and ArgyllCMS

### DIFF
--- a/docs/install_instructions_linux.md
+++ b/docs/install_instructions_linux.md
@@ -3,6 +3,27 @@
 Installation Instructions (Linux)
 =================================
 
+ArgyllCMS Requirement
+----------------------
+
+DisplayCAL relies on [ArgyllCMS](https://www.argyllcms.com/) to talk to your
+measurement instrument and take the actual readings, it is not bundled with any of
+the packages/installers or install methods described below and needs to be obtained
+separately.
+
+You don't have to grab it upfront though. The first time you launch DisplayCAL and it
+can't find a working ArgyllCMS installation, it will offer to either **download** a
+matching build for you automatically (from
+[eoyilmaz/argyllcms-binaries](https://github.com/eoyilmaz/argyllcms-binaries/releases)),
+or **browse** to an existing installation already on your system.
+
+If you'd rather install it yourself first (e.g. through your distro's package
+manager, or manually from the
+[ArgyllCMS releases page](https://github.com/eoyilmaz/argyllcms-binaries/releases)),
+that works too, DisplayCAL will pick it up automatically if it's on your `PATH`.
+Otherwise, point DisplayCAL at its `bin` folder via *File -> Locate ArgyllCMS
+executables...* whenever you need to change it.
+
 Install with Package
 ---------------------
 

--- a/docs/install_instructions_linux.md
+++ b/docs/install_instructions_linux.md
@@ -3,11 +3,47 @@
 Installation Instructions (Linux)
 =================================
 
-Although, there are currently no RPM, DEB or other common packages to install DisplayCAL
-directly under Linux, some distros supply recent DisplayCAL versions in their package
-management systems. Please search for them first.
+Install with Package
+---------------------
 
-Otherwise you can install DisplayCAL under Linux pretty easily.
+We publish DEB, RPM, Flatpak and AppImage packages for each
+[release](https://www.github.com/eoyilmaz/displaycal-py3/releases), and this is the
+preferred way of running DisplayCAL under Linux (unless you want to test the latest
+code). Pick whichever matches your distro/preference:
+
+* `DisplayCAL-<version>-Linux-amd64.deb`, for Debian/Ubuntu and other DEB-based distros:
+
+  ```shell
+  sudo apt install ./DisplayCAL-<version>-Linux-amd64.deb
+  ```
+
+* `DisplayCAL-<version>-Linux-x86_64.rpm`, for Fedora/openSUSE and other RPM-based
+  distros:
+
+  ```shell
+  sudo dnf install ./DisplayCAL-<version>-Linux-x86_64.rpm
+  ```
+
+* `DisplayCAL-<version>-Linux-x86_64.flatpak`, distro-independent:
+
+  ```shell
+  flatpak install ./DisplayCAL-<version>-Linux-x86_64.flatpak
+  ```
+
+* `DisplayCAL-<version>-Linux-x86_64.AppImage`, distro-independent, no installation
+  needed:
+
+  ```shell
+  chmod +x DisplayCAL-<version>-Linux-x86_64.AppImage
+  ./DisplayCAL-<version>-Linux-x86_64.AppImage
+  ```
+
+Also, some distros supply recent DisplayCAL versions in their own package management
+systems, please search for them first if you'd rather use your distro's native
+packaging.
+
+If none of these suit your needs, you can install DisplayCAL under Linux pretty easily
+through PyPI or by building it from source, as described below.
 
 Prerequisites
 -------------

--- a/docs/install_instructions_macos.md
+++ b/docs/install_instructions_macos.md
@@ -1,6 +1,26 @@
 Installation Instructions (MacOS)
 =================================
 
+ArgyllCMS Requirement
+----------------------
+
+DisplayCAL relies on [ArgyllCMS](https://www.argyllcms.com/) to talk to your
+measurement instrument and take the actual readings, it is not bundled with the
+installer or any of the install methods described below and needs to be obtained
+separately.
+
+You don't have to grab it upfront though. The first time you launch DisplayCAL and it
+can't find a working ArgyllCMS installation, it will offer to either **download** a
+matching build for you automatically (from
+[eoyilmaz/argyllcms-binaries](https://github.com/eoyilmaz/argyllcms-binaries/releases)),
+**browse** to an existing installation already on your system, or use a
+Homebrew-installed copy if one is detected (`brew install argyll-cms`).
+
+If you'd rather install it yourself first, that works too, DisplayCAL will pick it up
+automatically if it's on your `PATH` (including via Homebrew). Otherwise, point
+DisplayCAL at its `bin` folder via *DisplayCAL -> Locate ArgyllCMS executables...*
+whenever you need to change it.
+
 Install with Installer
 ----------------------
 

--- a/docs/install_instructions_macos.md
+++ b/docs/install_instructions_macos.md
@@ -6,7 +6,11 @@ Install with Installer
 
 We now have a proper [installer](https://www.github.com/eoyilmaz/displaycal-py3/releases)
 for MacOS and this is the preferred way of running DisplayCAL under MacOS (unless you
-want to test the latest code).
+want to test the latest code). Each release publishes two disk images, pick the one
+matching your Mac:
+
+* `DisplayCAL-<version>-macOS-arm64.dmg`, for Apple Silicon Macs (M1 and newer)
+* `DisplayCAL-<version>-macOS-x86_64.dmg`, for Intel Macs
 
 > [!NOTE]
 > ArgyllCMS 3.5.0 adds native Apple Silicon binaries

--- a/docs/install_instructions_windows.md
+++ b/docs/install_instructions_windows.md
@@ -1,6 +1,24 @@
 Installation Instructions (Windows)
 ===================================
 
+ArgyllCMS Requirement
+----------------------
+
+DisplayCAL relies on [ArgyllCMS](https://www.argyllcms.com/) to talk to your
+measurement instrument and take the actual readings, it is not bundled with the
+installer or any of the install methods described below and needs to be obtained
+separately.
+
+You don't have to grab it upfront though. The first time you launch DisplayCAL and it
+can't find a working ArgyllCMS installation, it will offer to either **download** a
+matching build for you automatically (from
+[eoyilmaz/argyllcms-binaries](https://github.com/eoyilmaz/argyllcms-binaries/releases)),
+or **browse** to an existing installation already on your system.
+
+If you'd rather install it yourself first, that works too, DisplayCAL will pick it up
+automatically if it's on your `PATH`. Otherwise, point DisplayCAL at its `bin` folder
+via *File -> Locate ArgyllCMS executables...* whenever you need to change it.
+
 Install with Installer
 ----------------------
 

--- a/docs/install_instructions_windows.md
+++ b/docs/install_instructions_windows.md
@@ -6,7 +6,12 @@ Install with Installer
 
 We now have a proper [installer](https://www.github.com/eoyilmaz/displaycal-py3/releases) for Windows
 and this is the preferred way of running DisplayCAL under Windows (unless you want to
-test the latest code).
+test the latest code). Each release publishes two installers, pick the one matching your
+system:
+
+* `DisplayCAL-<version>-Windows-x64.exe`, for regular 64-bit (x86_64) Windows systems
+* `DisplayCAL-<version>-Windows-arm64.exe`, for Windows on ARM (e.g. Snapdragon-based
+  laptops)
 
 > [!NOTE]
 > ArgyllCMS 3.5.0 adds native Windows ARM64 binaries (`Argyll_V3.5.0_win_arm64_exe.zip`)


### PR DESCRIPTION
## Summary
- Documents the Linux DEB/RPM/Flatpak/AppImage packages we now publish per release (the docs previously claimed none existed)
- Clarifies the arch-specific macOS (`arm64`/`x86_64` `.dmg`) and Windows (`x64`/`arm64` `.exe`) installer assets
- Adds an "ArgyllCMS Requirement" section to all three platform docs explaining that ArgyllCMS ships separately and isn't bundled with any package/installer, and documents the built-in first-run download/browse/Homebrew prompt as well as the manual install path

Closes #954

## Test plan
- [x] Verified release asset names against the actual 3.9.19 GitHub release
- [x] Verified the ArgyllCMS first-run download/browse/Homebrew prompt behavior against `DisplayCAL/argyll.py::set_argyll_bin` and `DisplayCAL/display_cal.py`
- [x] Verified the `Locate ArgyllCMS executables...` menu label against `DisplayCAL/lang/en.yaml`
- [x] Verified the `argyll-cms` Homebrew formula name via `brew search`
- [x] Docs-only change, no functional testing needed