### PR TITLE
[Qt] Make colorimeter correction web-check dialog columns sortable

### DIFF
--- a/DisplayCAL/ui/colorimeter_correction_io.py
+++ b/DisplayCAL/ui/colorimeter_correction_io.py
@@ -167,8 +167,28 @@ def save_correction(cgats_bytes: bytes, parent: QWidget | None = None) -> bool:
 # -- Web check ----------------------------------------------------------------
 
 
+class _NumericTableWidgetItem(QTableWidgetItem):
+    """Table item that sorts numerically instead of lexicographically.
+
+    Falls back to the base class's text comparison for values that aren't
+    parseable as ``float`` (e.g. "unknown"/"not_applicable" placeholders).
+    """
+
+    def __lt__(self, other: QTableWidgetItem) -> bool:
+        try:
+            return float(self.text()) < float(other.text())
+        except (TypeError, ValueError):
+            # Not super().__lt__(other): PySide's vtable slot for this
+            # virtual still points at this very override regardless of the
+            # MRO, so calling up re-enters here and recurses forever.
+            return self.text() < other.text()
+
+
 class _WebCheckChooserDialog(QDialog):
     """List the corrections the online DB returned and let the user pick one."""
+
+    #: Columns sorted numerically (ΔE*00 values) rather than as plain text.
+    _NUMERIC_COLUMN_KEYS = frozenset({"fit_avg_de00", "fit_max_de00"})
 
     _COLUMN_KEYS = (
         "type",
@@ -186,7 +206,6 @@ class _WebCheckChooserDialog(QDialog):
     def __init__(self, rows: list[dict], parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle(lang.getstr("colorimeter_correction.web_check"))
-        self._rows = rows
         self.selected_cgats: bytes | None = None
 
         layout = QVBoxLayout(self)
@@ -211,8 +230,20 @@ class _WebCheckChooserDialog(QDialog):
         table.setEditTriggers(QTableWidget.NoEditTriggers)
         for r, row in enumerate(rows):
             for c, key in enumerate(self._COLUMN_KEYS):
-                table.setItem(r, c, QTableWidgetItem(str(row[key])))
+                item_cls = (
+                    _NumericTableWidgetItem
+                    if key in self._NUMERIC_COLUMN_KEYS
+                    else QTableWidgetItem
+                )
+                item = item_cls(str(row[key]))
+                if c == 0:
+                    # Sorting reorders rows visually, so the row's source
+                    # dict travels with its item rather than being looked up
+                    # by position in `rows` later.
+                    item.setData(Qt.UserRole, row)
+                table.setItem(r, c, item)
         table.resizeColumnsToContents()
+        table.setSortingEnabled(True)
         table.itemSelectionChanged.connect(self._update_ok_state)
         self._table = table
         layout.addWidget(table)
@@ -242,7 +273,8 @@ class _WebCheckChooserDialog(QDialog):
     def accept(self) -> None:
         rows = self._table.selectionModel().selectedRows()
         if rows:
-            self.selected_cgats = self._rows[rows[0].row()]["cgats"]
+            row = self._table.item(rows[0].row(), 0).data(Qt.UserRole)
+            self.selected_cgats = row["cgats"]
         super().accept()
 
 

--- a/tests/test_ui_colorimeter_correction_io.py
+++ b/tests/test_ui_colorimeter_correction_io.py
@@ -100,6 +100,63 @@ class TestWebCheckChooserDialog:
         dialog._table.selectRow(1)
         assert dialog._buttons.button(ccio.QDialogButtonBox.Ok).isEnabled()
 
+    def test_table_is_sortable(self, qapp):
+        dialog = ccio._WebCheckChooserDialog([_ROW], None)
+        assert dialog._table.isSortingEnabled()
+
+    def test_de00_columns_sort_numerically_not_lexicographically(self, qapp):
+        from qtpy.QtCore import Qt as _Qt
+
+        rows = [
+            dict(_ROW, cgats=b"A", display="A Display", fit_avg_de00="10.0"),
+            dict(_ROW, cgats=b"B", display="B Display", fit_avg_de00="2.0"),
+            dict(_ROW, cgats=b"C", display="C Display", fit_avg_de00="1.5"),
+        ]
+        dialog = ccio._WebCheckChooserDialog(rows, None)
+        col = dialog._COLUMN_KEYS.index("fit_avg_de00")
+        dialog._table.sortByColumn(col, _Qt.AscendingOrder)
+        displays = [
+            dialog._table.item(r, 0).data(_Qt.UserRole)["display"]
+            for r in range(dialog._table.rowCount())
+        ]
+        # Numeric order (1.5 < 2.0 < 10.0), not lexicographic ("1.5" <
+        # "10.0" < "2.0").
+        assert displays == ["C Display", "B Display", "A Display"]
+
+    def test_de00_column_sort_with_non_numeric_values_does_not_recurse(self, qapp):
+        # Regression test: rows where fit_max_de00 is "Not applicable" (CCSS
+        # entries, not CCMX) mixed with numeric CCMX entries once triggered
+        # infinite recursion, because the non-numeric fallback called
+        # super().__lt__(), which PySide re-dispatches back to this very
+        # override rather than the base implementation.
+        from qtpy.QtCore import Qt as _Qt
+
+        rows = [
+            dict(_ROW, cgats=b"A", display="A Display", fit_max_de00="Not applicable"),
+            dict(_ROW, cgats=b"B", display="B Display", fit_max_de00="2.0"),
+            dict(_ROW, cgats=b"C", display="C Display", fit_max_de00="1.0"),
+        ]
+        dialog = ccio._WebCheckChooserDialog(rows, None)
+        col = dialog._COLUMN_KEYS.index("fit_max_de00")
+        dialog._table.sortByColumn(col, _Qt.AscendingOrder)
+        assert dialog._table.rowCount() == 3
+
+    def test_accept_returns_correct_row_after_sorting(self, qapp):
+        from qtpy.QtCore import Qt as _Qt
+
+        rows = [
+            dict(_ROW, cgats=b"A", display="A Display", fit_avg_de00="10.0"),
+            dict(_ROW, cgats=b"B", display="B Display", fit_avg_de00="2.0"),
+            dict(_ROW, cgats=b"C", display="C Display", fit_avg_de00="1.5"),
+        ]
+        dialog = ccio._WebCheckChooserDialog(rows, None)
+        col = dialog._COLUMN_KEYS.index("fit_avg_de00")
+        dialog._table.sortByColumn(col, _Qt.AscendingOrder)
+        # After sorting, visual row 0 is "C Display" (lowest ΔE*00 avg).
+        dialog._table.selectRow(0)
+        dialog.accept()
+        assert dialog.selected_cgats == b"C"
+
 
 class TestWebCheckController:
     def test_fetch_failure_shows_message_and_finishes(self, qapp, worker, monkeypatch):


### PR DESCRIPTION
## Summary

- Closes #958. `_WebCheckChooserDialog`'s `QTableWidget` now has `setSortingEnabled(True)`, so clicking a column header sorts ascending/descending as usual.
- The ΔE*00 avg/max columns sort numerically instead of lexicographically, via a `_NumericTableWidgetItem` subclass overriding `__lt__()` to compare as `float` (falling back to text comparison for non-numeric placeholders like "Not applicable").
- Fixed a latent bug that sorting would have exposed: `accept()` picked the selected row's data by indexing the original `rows` list with the table's visual row number, which is wrong once sorting reorders rows. Each row's source dict is now stashed on its first-column item via `Qt.UserRole` and read back from the table, independent of sort order.
- Fixed a `RecursionError` found while testing: the numeric item's non-numeric fallback originally called `super().__lt__(other)`, but PySide's vtable slot for that virtual still resolves back to the Python override regardless of `super()`, so it recursed infinitely on any pairing involving a non-numeric ΔE*00 value (e.g. CCSS entries showing "Not applicable"). Replaced with a direct text comparison.
- Confirmed against the wx equivalent (`colorimeter_correction_web_check_choose` in `display_cal.py`), which uses a plain, unsorted `wx.ListCtrl`, so this is a net-new Qt enhancement rather than a parity fix.

## Test plan

- [x] `pytest tests/test_ui_colorimeter_correction_io.py` — 19/20 pass (one pre-existing, unrelated `ImportController` failure present on `develop` too)
- [x] New tests: sorting is enabled, ΔE*00 columns sort numerically not lexicographically, row selection resolves correctly after sorting, and a regression test for the mixed numeric/non-numeric recursion bug (verified it actually catches the bug by temporarily reintroducing `super().__lt__()`)
- [x] `ruff check DisplayCAL/ui/colorimeter_correction_io.py` clean