### PR TITLE
[#962] Pin wxPython to 4.2.5, fix Linux AppImage/Flatpak build failure

### DIFF
--- a/misc/appimage/build-appimage.sh
+++ b/misc/appimage/build-appimage.sh
@@ -59,9 +59,17 @@ LIBPYTHON="$(ldd "$(command -v "python${PYVER}")" | awk '/libpython/{print $3}')
 # 2. Install DisplayCAL and its dependencies straight into that prefix,
 #    including the Ubuntu-matched wxPython wheel.
 "$APPDIR/usr/bin/python3" -m ensurepip --upgrade
+# --only-binary wxpython: this script only installs runtime libraries (see
+# top-of-file note), not the gtk+-3.0/libcurl dev headers a from-source
+# wxPython build needs. Without this flag, a wxPython release that has no
+# prebuilt wheel here yet (upstream published, extras.wxpython.org hasn't
+# caught up) silently falls through to a slow from-source build that then
+# fails on missing headers; this instead fails fast with a clear
+# "no matching distribution" error.
 "$APPDIR/usr/bin/python3" -m pip install --upgrade \
   --prefix "$APPDIR/usr" \
   --find-links "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-${UBUNTU_RELEASE}/" \
+  --only-binary wxpython \
   "$WHEEL_PATH"
 
 # 2b. Prune Qt subsystems DisplayCAL/pyqtgraph/qtpy never import (verified via

--- a/misc/flatpak/net.displaycal.DisplayCAL.yml
+++ b/misc/flatpak/net.displaycal.DisplayCAL.yml
@@ -98,11 +98,22 @@ modules:
       # pip resolve the newest compatible one) so this can't silently pick a
       # release extras.wxpython.org hasn't built a wheel for yet and fall
       # through to that broken from-source path; --only-binary makes that
-      # failure mode a fast, clear pip error instead. It's built against
-      # Ubuntu 22.04's GTK3/WebKit2GTK, not the SDK's own, so if the
-      # resulting wxPython fails to import at runtime, that ABI mismatch is
-      # the first thing to suspect and this module should fall back to
-      # building from source.
+      # failure mode a fast, clear pip error instead.
+      #
+      # The ubuntu-22.04 wheel is deliberate, not a stale leftover from an
+      # older CI image: this build runs sandboxed inside org.freedesktop.
+      # Platform//25.08 (see runtime-version above), not the raw Ubuntu CI
+      # host, so there's no "match the wheel to the runner's Ubuntu version"
+      # fix to make here even though the runner itself is 24.04. The 22.04
+      # wheel needs old-ABI libs the Freedesktop runtime doesn't ship
+      # (libjpeg.so.8/libtiff.so.5/libjbig.so.0/libdeflate.so.0, see the
+      # libjpeg8/libtiff5/libjbig0/libdeflate0 modules below), extracted by
+      # hand from Jammy .debs after several rounds of "cannot open shared
+      # object file" failures (issue #232). Switching to the ubuntu-24.04
+      # wheel would link against different SONAMEs (Noble dropped libtiff5
+      # for libtiff6 entirely, see build-appimage.sh) and would need those
+      # shim modules reworked and re-verified on real Linux hardware, not
+      # just re-pointing this URL.
       - pip3 install --prefix=/app --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ --only-binary wxpython wxPython==4.2.5
 
   - name: python-dbus

--- a/misc/flatpak/net.displaycal.DisplayCAL.yml
+++ b/misc/flatpak/net.displaycal.DisplayCAL.yml
@@ -93,13 +93,17 @@ modules:
       # which is what org.freedesktop.Sdk 25.08 ships: wxPython 4.2.2's
       # bundled build.py monkey-patches distutils.copy_file() with a
       # signature that no longer matches modern setuptools). Point pip at
-      # the same extras.wxpython.org index our pytest.yml CI uses instead,
-      # letting it resolve the newest compatible version rather than pinning
-      # one by hand. It's built against Ubuntu 22.04's GTK3/WebKit2GTK, not
-      # the SDK's own, so if the resulting wxPython fails to import at
-      # runtime, that ABI mismatch is the first thing to suspect and this
-      # module should fall back to building from source.
-      - pip3 install --prefix=/app --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython
+      # the same extras.wxpython.org index our pytest.yml CI uses instead.
+      # Pinned to the exact version in requirements.txt (rather than letting
+      # pip resolve the newest compatible one) so this can't silently pick a
+      # release extras.wxpython.org hasn't built a wheel for yet and fall
+      # through to that broken from-source path; --only-binary makes that
+      # failure mode a fast, clear pip error instead. It's built against
+      # Ubuntu 22.04's GTK3/WebKit2GTK, not the SDK's own, so if the
+      # resulting wxPython fails to import at runtime, that ABI mismatch is
+      # the first thing to suspect and this module should fall back to
+      # building from source.
+      - pip3 install --prefix=/app --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ --only-binary wxpython wxPython==4.2.5
 
   - name: python-dbus
     buildsystem: simple

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,13 @@ qtpy >= 2.4
 Send2Trash
 typing_extensions; python_version < "3.11"
 WMI; sys_platform == "win32"
-# wxPython is being phased out in favour of Qt (qtpy/PySide6) for DisplayCAL 4.0.
-# It is still required by the not-yet-ported legacy wx_* modules.
-wxPython >= 4.2.2
+# wxPython is being phased out in favour of Qt (qtpy/PySide6) for DisplayCAL 4.0
+# and is only still required by the not-yet-ported legacy wx_* modules, so
+# pinned to the last version we've verified rather than left open-ended.
+# Capping matters most on Linux: wxPython has no PyPI wheels there at all
+# (built instead by extras.wxpython.org, which lags upstream releases by
+# distro), so an unpinned install can pick a version with no Linux wheel yet
+# and fall back to a from-source sdist build our CI images aren't set up for
+# (missing gtk+-3.0/libcurl dev headers).
+wxPython == 4.2.5
 zeroconf


### PR DESCRIPTION
## Summary
- Nightly and release Linux AppImage builds were failing: wxPython 4.3.0 was just published to PyPI with no Linux wheels (macOS/Windows only), so pip picked it as the newest match for `requirements.txt`'s unbounded `wxPython >= 4.2.2`, found no wheel anywhere for Linux, and fell back to building wxWidgets from source, which fails since the AppImage job only installs runtime GTK/X11 libraries, not the `gtk+-3.0`/`libcurl` dev headers a source build needs.
- Pins `wxPython==4.2.5` in `requirements.txt` (matching what `pytest.yml` already pins independently) and in the Flatpak manifest's `python-wxPython` module, since wxPython is being phased out for Qt anyway and doesn't need to track every upstream release.
- Adds `--only-binary wxpython` to `build-appimage.sh` and the Flatpak module so a future version drift fails fast with a clear pip error instead of silently attempting a doomed multi-minute source build.
- Documents (in the Flatpak manifest) why the `python-wxPython` module deliberately stays on the `ubuntu-22.04` extras.wxpython.org wheel rather than `ubuntu-24.04`, even though the CI runner itself is 24.04: `flatpak-builder` builds that module sandboxed inside `org.freedesktop.Platform//25.08`, not the raw host, and the 22.04 wheel's ABI is what the hand-built `libjpeg8`/`libtiff5`/`libjbig0`/`libdeflate0` shim modules (issue #232) are matched to.

Fixes #962.

## Test plan
- [x] Nightly AppImage build workflow run succeeds
- [x] Nightly Flatpak build workflow run succeeds
- [x] Release AppImage/Flatpak build workflow run succeeds (shares `build-appimage.sh` and the same Flatpak manifest)