### PR TITLE
Fix: use encoding= keyword for open() in ccmx.py

### DIFF
--- a/DisplayCAL/ccmx.py
+++ b/DisplayCAL/ccmx.py
@@ -48,7 +48,7 @@ def convert_devicecorrections_to_ccmx(path: str, target_dir: str) -> tuple[int, 
         tuple[int, int]: A tuple containing the number of imported and skipped
             entries.
     """
-    with open(path, "utf8") as devcorrections_file:
+    with open(path, encoding="utf8") as devcorrections_file:
         lines = devcorrections_file.read().strip().splitlines()
     # Convert to JSON
     # The DeviceCorrections.txt format is as follows, so a conversion is pretty


### PR DESCRIPTION
Generated with AI assistance by goose (AAIF).

## Problem

`convert_devicecorrections_to_ccmx()` in `DisplayCAL/ccmx.py` called `open(path, "utf8")` passing `"utf8"` as the file mode positional argument instead of as the encoding. On Python 3.14, which has stricter mode validation, this raises:

```
Error("File invalid.\ninvalid mode: 'utf8'")
```

This prevented importing iColorDisplay colorimeter corrections at startup.

## Fix

Changed `open(path, "utf8")` to `open(path, encoding="utf8")`.