### PR TITLE
Fix colord profile installation failures on Wayland

### DIFF
--- a/DisplayCAL/colord.py
+++ b/DisplayCAL/colord.py
@@ -642,7 +642,66 @@ def import_profile(
             f"Trying to import profile '{profile.filename}' failed after {n} tries."
         )
 
-    return query_colord_for_newly_added_profile(profile_id, timeout=timeout)
+    # Try to find the profile by the ICC profile.ID-based profile_id first.
+    # If that fails (because colord uses a different ID scheme based on the
+    # file checksum), fall back to finding by filename, which is reliable
+    # and locale-independent.
+    try:
+        return query_colord_for_newly_added_profile(profile_id, timeout=timeout)
+    except CDTimeoutError:
+        pass
+
+    # Fallback: use colormgr find-profile-by-filename to locate the profile
+    # that was just imported. This works regardless of the ID scheme colord
+    # uses internally (md5 of file contents vs. ICC profile.ID header).
+    for _ in range(int(timeout / 1.0)):
+        with contextlib.suppress(CDObjectQueryError, CDObjectNotFoundError):
+            cdprofile = _find_profile_by_filename(cmd, profile_install_name)
+            if cdprofile:
+                return cdprofile
+        sleep(1)
+
+    raise CDTimeoutError(
+        f"Querying for profile {profile_id!r} (and by filename "
+        f"{profile_install_name!r}) returned no result for {timeout} secs"
+    )
+
+
+def _find_profile_by_filename(cmd: str, filename: str) -> None | str:
+    """Find a profile in colord by its filename using colormgr.
+
+    This is a fallback for when the profile ID-based lookup fails, e.g.
+    because colord uses a different ID scheme (md5 of file contents) than
+    the ICC profile.ID header that DisplayCAL uses.
+
+    Args:
+        cmd (str): The colormgr command path.
+        filename (str): The filename of the profile to search for.
+
+    Returns:
+        None | str: The D-Bus object path of the profile, or None if not found.
+    """
+    args = [cmd, "find-profile-by-filename", filename]
+    try:
+        process = sp.Popen(args, stdout=sp.PIPE, stderr=sp.STDOUT)
+        stdout, _ = process.communicate()
+    except Exception:
+        return None
+    if process.returncode != 0 or not stdout.strip():
+        return None
+    # Parse the object path from the output. colormgr outputs it on a line
+    # like "Object path:     /org/freedesktop/ColorManager/profiles/..."
+    # (or the locale-translated equivalent, e.g. "Objektsti:" in Norwegian).
+    # We match by the D-Bus object path pattern which is locale-independent.
+    for line in stdout.decode("utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if "/org/freedesktop/ColorManager/" in line:
+            # Extract just the path (may have a label prefix in non-English locales)
+            parts = line.split()
+            for part in parts:
+                if part.startswith("/org/freedesktop/ColorManager/"):
+                    return part
+    return None
 
 
 def query_colord_for_newly_added_profile(

--- a/DisplayCAL/display_cal.py
+++ b/DisplayCAL/display_cal.py
@@ -17542,8 +17542,13 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 prefixes = prefix.split(",")
                 # Set license
                 profile.tags.meta["License"] = getcfg("profile.license")
-                # Set device ID
-                device_id = self.worker.get_device_id(quirk=False)
+                # Set device ID. Use query=True to query colord for the device
+                # ID when EDID is unavailable (e.g. on Wayland where xrandr
+                # does not expose EDID blocks).
+                device_id = self.worker.get_device_id(quirk=False, query=True)
+                if not device_id:
+                    # Fall back to non-quirked without query
+                    device_id = self.worker.get_device_id(quirk=False)
                 if device_id:
                     profile.tags.meta["MAPPING_device_id"] = device_id
                     prefixes.append("MAPPING_")
@@ -19111,11 +19116,13 @@ class MainFrame(ReportFrame, BaseFrame, LUT3DMixin):
                 edid_md5_indexes = []
                 for i, edid in enumerate(self.worker.display_edid):
                     if display_name in (
-                        edid.get(b"monitor_name", False),
+                        edid.get("monitor_name", edid.get(b"monitor_name", False)),
                         self.worker.display_names[i],
                     ):
                         display_name_indexes.append(i)
-                    if edid_md5 == edid.get(b"hash", False):
+                    if edid_md5 == edid.get(
+                        "hash", edid.get(b"hash", False)
+                    ):
                         edid_md5_indexes.append(i)
 
                 if len(display_name_indexes) == 1:


### PR DESCRIPTION
Generated with AI assistance by goose (AAIF).

## Problem

After calibration and profiling, DisplayCAL fails to install the ICC profile via colord on Wayland systems. Three issues were identified:

### 1. CDTimeoutError — profile ID mismatch

DisplayCAL computes the colord profile ID from the ICC `profile.ID` header (`"icc-" + hexlify(profile.ID)`), but colord uses `"icc-" + md5(file_contents)` as its internal ID. The `query_colord_for_newly_added_profile()` function searches by the wrong ID and always times out after 5 seconds, raising `CDTimeoutError`.

### 2. Wrong MAPPING_device_id in profile metadata

On Wayland, `xrandr --verbose` does not expose EDID blocks, so `display_edid` is empty for all displays. The `MAPPING_device_id` was set using `get_device_id(quirk=False)` without `query=True`, which could not query colord for the correct device ID. This caused the profile to be tagged with the wrong display device.

### 3. EDID dict key type mismatch (bytes vs str)

`display_cal.py` used bytes keys (`b"monitor_name"`, `b"hash"`) to look up EDID fields, but `edid.py` stores them with str keys. This prevented EDID-based display matching from ever working.

## Fixes

1. **colord.py**: Added `_find_profile_by_filename()` fallback that uses `colormgr find-profile-by-filename` to locate the just-imported profile when the ID-based lookup times out. The object path is parsed from colormgr output by matching the `/org/freedesktop/ColorManager/` pattern, making it locale-independent.

2. **display_cal.py**: Changed `get_device_id(quirk=False)` to `get_device_id(quirk=False, query=True)` (matching the same pattern already used in `worker.py` line 13559), with a fallback to the non-query version.

3. **display_cal.py**: Now checks both str and bytes keys for EDID dict lookups.