### PR TITLE
Retry ICC reads after profile loader failures

### DIFF
--- a/DisplayCAL/profile_loader.py
+++ b/DisplayCAL/profile_loader.py
@@ -3803,6 +3803,7 @@ class ProfileLoader:
             if (
                 not self._reset_gamma_ramps
                 and (self._manual_restore or profile_association_changed)
+                and profile is not None
                 and profile.tags.get("vcgt")
             ):
                 print(lang.getstr("calibration.loading_from_display_profile"))
@@ -3833,6 +3834,8 @@ class ProfileLoader:
             vcgt_values = vcgt.get_values()[:3]
             if self._reset_gamma_ramps:
                 print("Caching linear gamma ramps")
+            elif profile is None:
+                print("Using temporary linear gamma ramps for profile", desc)
             else:
                 print("Caching implicit linear gamma ramps for profile", desc)
         else:
@@ -3851,11 +3854,15 @@ class ProfileLoader:
                 if j == 0:
                     vcgt_value += 1
                 vcgt_ramp_hack[k][j] = vcgt_value
-        self.ramps[self._reset_gamma_ramps or key] = (
-            vcgt_ramp,
-            vcgt_ramp_hack,
-            vcgt_values,
-        )
+        # A failed read must not turn the linear fallback into a cached
+        # calibration. The file may become readable without its association
+        # or modification time changing (e.g. after a sharing violation).
+        if self._reset_gamma_ramps or profile is not None:
+            self.ramps[self._reset_gamma_ramps or key] = (
+                vcgt_ramp,
+                vcgt_ramp_hack,
+                vcgt_values,
+            )
         recheck = True
         return recheck, vcgt_ramp, vcgt_ramp_hack, vcgt_values
 
@@ -3895,7 +3902,8 @@ class ProfileLoader:
                 self.profiles[key].tags.get("vcgt")
             except Exception as exception:
                 print(exception)
-                self.profiles[key] = ICCProfile()
+                self.profiles[key] = None
+                return vcgt_values, None
         profile = self.profiles[key]
         if isinstance(profile.tags.get("vcgt"), VideoCardGammaType):
             # Get display profile vcgt

--- a/tests/test_profile_loader_retry.py
+++ b/tests/test_profile_loader_retry.py
@@ -1,0 +1,89 @@
+"""Profile reads can fail while an installed ICC file is being replaced."""
+
+import struct
+from unittest import mock
+
+import pytest
+
+from DisplayCAL import profile_loader
+from DisplayCAL.colormath import get_rgb_space
+from DisplayCAL.icc_profile import ICCProfile, VideoCardGammaFormulaType
+
+
+def make_loader():
+    """Use the ramp code without starting a tray icon or touching the display."""
+    loader = profile_loader.ProfileLoader.__new__(profile_loader.ProfileLoader)
+    loader.profiles = {}
+    loader.ramps = {}
+    loader._reset_gamma_ramps = False
+    loader._manual_restore = False
+    loader._quantize = 65535.0
+    return loader
+
+
+def generate_ramp(loader, path, key="display-1"):
+    return loader._generate_gamma_ramp(
+        False, [], [], "Test display", key, str(path), False, "Test profile"
+    )[1]
+
+
+def make_profile(path, calibrated=True):
+    profile = ICCProfile.from_rgb_space(get_rgb_space("sRGB"), "Test profile")
+    if calibrated:
+        data = b"vcgt" + b"\0" * 4 + struct.pack(">I", 1)
+        data += struct.pack(">III", 2 * 65536, 0, 65536) * 3
+        profile.tags["vcgt"] = VideoCardGammaFormulaType(data, "vcgt")
+    profile.write(str(path))
+
+
+@pytest.mark.parametrize("failures", [1, 2])
+@pytest.mark.parametrize("manual_restore", [False, True])
+def test_profile_read_is_retried_without_an_association_change(
+    tmp_path, failures, manual_restore
+):
+    path = tmp_path / "calibrated.icc"
+    make_profile(path)
+    loader = make_loader()
+    loader._manual_restore = manual_restore
+    reads = 0
+
+    def read_profile(filename=None):
+        nonlocal reads
+        if filename:
+            reads += 1
+            if reads <= failures:
+                raise PermissionError("Profile is temporarily locked")
+        return ICCProfile(filename)
+
+    with mock.patch.object(profile_loader, "ICCProfile", side_effect=read_profile):
+        for _ in range(failures):
+            fallback = generate_ramp(loader, path)
+            assert fallback[0][128] == 32896
+        recovered = generate_ramp(loader, path)
+        # The file and association have not changed. Retry must replace the
+        # temporary linear fallback with the profile's gamma 2.0 calibration.
+        assert recovered[0][128] < 17000
+        assert reads == failures + 1
+        assert generate_ramp(loader, path) is recovered
+        assert reads == failures + 1
+
+
+@pytest.mark.parametrize("calibrated", [False, True])
+def test_successful_profiles_are_still_cached(tmp_path, calibrated):
+    path = tmp_path / "valid.icc"
+    make_profile(path, calibrated)
+    loader = make_loader()
+    with mock.patch.object(profile_loader, "ICCProfile", wraps=ICCProfile) as read:
+        ramp = generate_ramp(loader, path)
+        assert generate_ramp(loader, path) is ramp
+        read.assert_called_once_with(str(path))
+
+
+def test_explicit_reset_does_not_read_the_profile(tmp_path):
+    loader = make_loader()
+    loader._reset_gamma_ramps = True
+    with mock.patch.object(profile_loader, "ICCProfile", wraps=ICCProfile) as read:
+        ramp = generate_ramp(loader, tmp_path / "unused.icc")
+        assert ramp[0][128] == 32896
+        assert generate_ramp(loader, tmp_path / "unused.icc") is ramp
+        read.assert_not_called()


### PR DESCRIPTION
A failed ICC read leaves the Windows profile loader using linear calibration until its cache is invalidated or the loader is restarted. `_retrieve_profile_vcgt()` caches an empty `ICCProfile` on failure, then `_generate_gamma_ramp()` caches the resulting linear ramp. Later polls never retry the file if its association and mtime are unchanged.

Leave both cache entries unset after a failed read. The next poll retries the profile; successful reads, profiles without a VCGT tag, and explicit linear resets are still cached as before.

Validation: 27 tests pass across `test_profile_loader_retry.py` and `test_profile_loader.py`. The two recovery cases failed against unmodified `develop` because the ramp stayed linear. Coverage includes consecutive read failures, manual reloads, and successful caching. The tests use generated ICC files and do not touch display state.

Found while investigating a loader on Windows 11 ARM64 that kept restoring linear ramps after profile installation. Restarting that loader resolved the symptom. This cache failure also reproduces under x64 Python 3.12, but the original log did not capture the failed read, so I cannot yet tie that incident to this specific cause. Keeping this as a draft pending a live install/reload check.
